### PR TITLE
Add Claude Opus 4.7 model support

### DIFF
--- a/source/library/services/Anthropic/SvAnthropicService.js
+++ b/source/library/services/Anthropic/SvAnthropicService.js
@@ -29,6 +29,16 @@
     modelsJson () {
         return [
             {
+                "name": "claude-opus-4-7",
+                "title": "Claude Opus 4.7",
+                "subtitle": "",
+                "inputTokenLimit": 1000000, // 1M context included at standard pricing
+                "notes": "Uses a new tokenizer that may use up to 35% more tokens for the same text",
+                "outputTokenLimit": 128000, // 128k output tokens
+                "supportsTemperature": true,
+                "supportsTopP": false  // Anthropic doesn't allow both temperature and top_p
+            },
+            {
                 "name": "claude-opus-4-5-20251101",
                 "title": "Claude 4.5 Opus",
                 "subtitle": "",


### PR DESCRIPTION
## Summary
- Adds `claude-opus-4-7` as a new model option in `SvAnthropicService`
- Opus 4.7 includes 1M context window and 128k max output at standard pricing (no beta flags needed)
- Notes the new tokenizer which may use up to 35% more tokens for the same text
- Existing Opus 4.5 and Haiku 4.5 models remain available

## Test plan
- [ ] Verify model appears in the model selection UI
- [ ] Test API requests using the new model ID
- [ ] Confirm existing models still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)