### PR TITLE
Migrate image evaluation from SvImage to SvImageNode

### DIFF
--- a/source/library/services/ImaginePro/Image Eval Prompts/SvImageEvaluator/SvImageEvaluator.js
+++ b/source/library/services/ImaginePro/Image Eval Prompts/SvImageEvaluator/SvImageEvaluator.js
@@ -20,14 +20,14 @@
     initPrototypeSlots () {
 
         /**
-     * @member {SvImage} svImage
+     * @member {SvImageNode} svImage
      * @description The image to evaluate.
      * @category Data
      */
         {
             const slot = this.newSlot("svImage", null);
-            slot.setFinalInitProto(SvImage);
-            slot.setSlotType("SvImage");
+            slot.setFinalInitProto(SvImageNode);
+            slot.setSlotType("SvImageNode");
             slot.setLabel("Image to Evaluate");
             slot.setIsSubnodeField(true);
             slot.setShouldStoreSlot(true);
@@ -215,7 +215,7 @@
     }
 
     async asyncImageAsBase64 () {
-        const dataUrl = this.svImage().dataURL();
+        const dataUrl = await this.svImage().asyncDataUrl();
         if (!dataUrl) {
             throw new Error("Image has no data URL");
         }

--- a/source/library/services/ImaginePro/Image Eval Prompts/SvImageEvaluator/SvImageNode_evaluator.js
+++ b/source/library/services/ImaginePro/Image Eval Prompts/SvImageEvaluator/SvImageNode_evaluator.js
@@ -1,12 +1,12 @@
 "use strict";
 
 /**
- * @class SvImage_evaluator
- * @extends SvImage
- * @classdesc Category of SvImage adding prompt-based image scoring via SvImageEvaluator.
+ * @class SvImageNode_evaluator
+ * @extends SvImageNode
+ * @classdesc Category of SvImageNode adding prompt-based image scoring via SvImageEvaluator.
  */
 
-(class SvImage_evaluator extends SvImage {
+(class SvImageNode_evaluator extends SvImageNode {
 
     /**
      * @description Scores the image (0.0-1.0) for a given prompt.
@@ -22,4 +22,3 @@
     }
 
 }).initThisCategory();
-

--- a/source/library/services/ImaginePro/Image Eval Prompts/SvImageEvaluator/_imports.json
+++ b/source/library/services/ImaginePro/Image Eval Prompts/SvImageEvaluator/_imports.json
@@ -3,5 +3,5 @@
     "SvImageEvalChecklistMaker.js",
     "SvImageEvaluator.js",
     "SvImageEvaluators.js",
-    "SvImage_evaluator.js"
+    "SvImageNode_evaluator.js"
 ]

--- a/source/library/services/ImaginePro/Image Eval Prompts/SvImagineProImageEvalPrompt.js
+++ b/source/library/services/ImaginePro/Image Eval Prompts/SvImagineProImageEvalPrompt.js
@@ -31,13 +31,13 @@
             slot.setSyncsToView(true);
         }
 
-        // Result image URL data (the best matching image) - kept for compatibility
+        // Result image node (the best matching image) - blob-backed, no data URL round-trip
         {
-            const slot = this.newSlot("resultImageUrlData", null);
-            slot.setSlotType("String");
+            const slot = this.newSlot("resultImageNode", null);
+            slot.setSlotType("SvImageNode");
             slot.setLabel("Best Result Image");
             slot.setIsSubnodeField(true);
-            slot.setShouldStoreSlot(false); // transient; consumers convert to blob-backed imageNode immediately
+            slot.setShouldStoreSlot(false); // transient; consumers copy the blob directly
             slot.setSyncsToView(true);
             slot.setFieldInspectorClassName("SvImageWellField");
             slot.setCanEditInspection(false);
@@ -123,20 +123,18 @@
             this.appendStatus("Preparing to evaluate images...");
             this.imageEvaluators().removeAllSubnodes();
 
-            // setup image evaluators
+            // setup image evaluators - pass imageNode directly, no SvImage intermediary
             for (const fileToDownload of this.allResultImages()) {
                 await fileToDownload.asyncFetchIfNeeded();
-                const svImage = SvImage.clone();
-                svImage.setDataURL(await fileToDownload.asyncDataUrl());
                 const evaluator = this.imageEvaluators().add();
-                evaluator.setSvImage(svImage);
+                evaluator.setSvImage(fileToDownload.imageNode());
                 evaluator.setImageGenPrompt(this.prompt());
             }
 
             this.setStatus("Evaluating images...");
             await this.imageEvaluators().asyncEvaluate(); // evals in parallel
-            const bestImage = this.imageEvaluators().bestSvImage();
-            this.setResultImageUrlData(bestImage.dataURL());
+            const bestImageNode = this.imageEvaluators().bestSvImage();
+            this.setResultImageNode(bestImageNode);
             this.setStatus("Selected best image!");
 
             // Performance monitoring: Complete evaluation timing
@@ -159,6 +157,19 @@
    */
     bestImage () {
         return this.imageEvaluators().bestSvImage();
+    }
+
+    /**
+     * @description Backward-compatible async accessor for the best result image as a data URL.
+     * @returns {Promise<string|null>} The data URL of the best result image, or null.
+     * @category Results
+     */
+    async resultImageUrlData () {
+        const node = this.resultImageNode();
+        if (node && node.hasImage()) {
+            return await node.asyncDataUrl();
+        }
+        return null;
     }
 
     onUpdateSlotStatus (oldValue, newValue) {


### PR DESCRIPTION
## Summary

- **SvImageEvaluator**: Change `svImage` slot from `SvImage` to `SvImageNode`; use async `asyncDataUrl()` instead of synchronous `dataURL()` — fixes "Image has no data URL" error
- **SvImagineProImageEvalPrompt**: Replace `resultImageUrlData` (String) slot with `resultImageNode` (SvImageNode); pass `fileToDownload.imageNode()` directly to evaluators instead of creating `SvImage` clones with data URL round-trips; add backward-compatible async `resultImageUrlData()` method
- **SvImage_evaluator → SvImageNode_evaluator**: Port evaluator category from `SvImage` to `SvImageNode`

## Context

Image generation fails with "Image has no data URL" because `SvImageEvaluator.asyncImageAsBase64()` calls the synchronous `svImage.dataURL()` on an `SvImage` instance whose data URL may be null. Images are now stored as blobs in `SvImageNode` (content-addressable blob pool), but the evaluation pipeline still created legacy `SvImage` objects and used synchronous data URL access.

This PR switches the evaluation pipeline to use `SvImageNode` directly, eliminating the unnecessary `SvImage` intermediary and the fragile data URL round-trips.

## ⚠️ Dependency

The companion app-level PR in undreamedof.ai depends on this PR being merged first.

## Test plan

- [ ] Trigger image generation during a game session (via AI `generateImage` tool call)
- [ ] Verify images generate without "Image has no data URL" error
- [ ] Verify image evaluation completes and selects best image
- [ ] Verify final image displays in chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)