### PR TITLE
SvXaiService: remove retired Grok slugs

### DIFF
--- a/source/library/services/Xai/SvXaiService.js
+++ b/source/library/services/Xai/SvXaiService.js
@@ -42,34 +42,7 @@
                 "title": "Grok 4",
                 "inputTokenLimit": 256000,
                 "outputTokenLimit": 256000
-            },
-            {
-                "name": "grok-4-1-fast-reasoning",
-                "title": "Grok 4.1 Fast Reasoning",
-                "inputTokenLimit": 131072,
-                "outputTokenLimit": 16384
-            },
-            {
-                "name": "grok-4-1-fast-non-reasoning",
-                "title": "Grok 4.1 Fast Non-Reasoning",
-                "inputTokenLimit": 131072,
-                "outputTokenLimit": 16384
             }
-            /*
-      // these other models may not be good enough to work properly
-      {
-        "name": "grok-3-mini",
-        "title": "Grok 3 Mini",
-        "inputTokenLimit": 131072,
-        "outputTokenLimit": 16384 // just a guess as I can't find it in the docs
-      },
-      {
-        "name": "grok-2-latest",
-        "title": "Grok 2 Latest",
-        "inputTokenLimit": 131072,
-        "outputTokenLimit": 8192 // jsut a guess as I can't find it in the docs
-      }
-      */
         ];
     }
 


### PR DESCRIPTION
## Summary

- Removes `grok-4-1-fast-reasoning` and `grok-4-1-fast-non-reasoning` from the user-facing model list in `SvXaiService.modelsJson()` — both were retired by xAI on 2026-05-15.
- Also drops the commented-out `grok-3-mini` and `grok-2-latest` entries (also retired/legacy).
- Keeps `grok-4-latest` as the sole entry. It is an alias that resolves to `grok-4.3` per xAI's current docs.

## Why

Per [xAI's May-15-2026 retirement notice](https://docs.x.ai/developers/migration/may-15-retirement), requests to the deprecated slugs still resolve but are billed at `grok-4.3` rates. Keeping them in the model picker means users select a label like "Grok 4.1 Fast Reasoning" but actually get billed for `grok-4.3` — a different model than the UI suggests. Removing them avoids the confusion.

Token limits on the remaining `grok-4-latest` entry are left untouched (would require verifying current `grok-4.3` limits — out of scope for this cleanup).

## Test plan

- [ ] Confirm the xAI model picker in the strvct services UI no longer lists the retired slugs.
- [ ] Confirm a request via `grok-4-latest` still routes successfully (it remains a valid alias for `grok-4.3`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)