### PR TITLE
Midjourney prompt: configurable --v (blank default) + native image prompts

### DIFF
--- a/source/library/services/ImaginePro/Text to Image/SvImagineProImagePrompt.js
+++ b/source/library/services/ImaginePro/Text to Image/SvImagineProImagePrompt.js
@@ -10,11 +10,16 @@
 /**
  * @class SvImagineProImagePrompt
  * @extends SvSummaryNode
- * @classdesc Represents an ImaginePro image prompt for generating images using Midjourney via ImaginePro API.
+ * @classdesc Represents a Midjourney image prompt (sent via the MJ-API gateway).
  *
- * IMPORTANT: This implementation ONLY supports Midjourney V7 or later versions.
- * We do NOT support V6 or earlier versions. All prompts will be sent with --v 7 flag.
- * Omnireference uses V7's --oref and --ow parameters (not V6's --cref/--cw).
+ * The Midjourney version is controlled by the `version` slot, which is EMPTY
+ * by default — no `--v` flag is sent, so the service uses its current default.
+ * App callers set the version explicitly (e.g. "8.1").
+ *
+ * Character/scene references are passed as native Midjourney "image prompts"
+ * (bare image URLs at the front of the prompt) via `extraImagesNode`. The
+ * older V7 omnireference channel (`--oref`/`--ow`) is still implemented but is
+ * no longer used by the app scene path.
  */
 
 (class SvImagineProImagePrompt extends SvSummaryNode {
@@ -92,6 +97,33 @@
             slot.setDuplicateOp("duplicate");
             slot.setSlotType("String");
             slot.setValidValues(["midjourney"]);
+            slot.setIsSubnodeField(true);
+            slot.setSummaryFormat("key: value");
+        }
+
+        /**
+         * @member {string} version
+         * @description The Midjourney version flag value. Empty = emit no --v
+         * flag (the service uses its current default). App callers set this
+         * explicitly (e.g. "8.1"). See composeVersionPrompt().
+         * @category Configuration
+         */
+        {
+            const validItems = [
+                { value: "", label: "(service default)" },
+                { value: "7", label: "7" },
+                { value: "8", label: "8" },
+                { value: "8.1", label: "8.1" }
+            ];
+            const slot = this.newSlot("version", "");
+            slot.setInspectorPath("Settings");
+            slot.setLabel("Version");
+            slot.setShouldStoreSlot(true);
+            slot.setSyncsToView(true);
+            slot.setDuplicateOp("duplicate");
+            slot.setSlotType("String");
+            slot.setValidItems(validItems);
+            slot.setValidValuesArePermissive(true);
             slot.setIsSubnodeField(true);
             slot.setSummaryFormat("key: value");
         }
@@ -771,16 +803,29 @@ Midjourney
     }
 
     async asyncComposeExtraImagesPrompt () {
+        // Native Midjourney "image prompts": bare image URLs at the front of
+        // the prompt. The image weight (--iw) is a single overall value and is
+        // emitted once in the parameters section by composeImageWeightPrompt().
         const extraImageUrls = await this.extraImagesNode().subnodes().promiseParallelMap(async svImageNode => {
             const url = await svImageNode.asyncPublicUrl();
             this.assertPublicUrl(url, "Extra image");
             return url;
         });
-        let prompt = extraImageUrls.join(" ");
-        if (extraImageUrls.length === 1) {
-            prompt += "--iw " + this.extraImagesWeight();
+        return extraImageUrls.join(" ");
+    }
+
+    composeImageWeightPrompt () {
+        // --iw applies to all image prompts as a single overall weight.
+        if (this.extraImagesNode().subnodes().length > 0) {
+            return "--iw " + this.extraImagesWeight();
         }
-        return prompt;
+        return "";
+    }
+
+    composeVersionPrompt () {
+        // Empty version => emit no --v flag (let the service use its default).
+        const v = this.version() ? String(this.version()).trim() : "";
+        return v.length > 0 ? "--v " + v : "";
     }
 
     async asyncComposeOrefPrompt () {
@@ -850,7 +895,8 @@ Midjourney
         parts.push(await this.asyncComposeSrefPrompt());
 
         parts.push(this.composeOptionalParametersPrompt());
-        parts.push(" --v 7"); // IMPORTANT: We require Midjourney V7
+        parts.push(this.composeImageWeightPrompt());
+        parts.push(this.composeVersionPrompt());
 
         const fullPrompt = parts.join(" ");
         console.log("composeFullPrompt: [\n" + fullPrompt + "\n]");


### PR DESCRIPTION
Part of undreamedof.ai **UO-382** — moving scene image generation off the V7 omnireference (`--oref`) mosaic and onto native Midjourney image prompts, and making the version flag configurable.

## What changed (`SvImagineProImagePrompt`)

- **`version` slot** — default **empty**, so by default no `--v` flag is emitted and the service uses its current default. Valid items `"" / 7 / 8 / 8.1` (permissive). App callers set it explicitly (undreamedof sets `8.1`).
- **`composeVersionPrompt()`** replaces the hardcoded `" --v 7"`.
- **`composeImageWeightPrompt()`** emits `--iw <weight>` **once** when any image prompts are present — fixing the prior bug where `--iw` was only appended for exactly one image and was missing a leading space.
- **`asyncComposeExtraImagesPrompt()`** now returns just the leading image-prompt URLs.
- Updated the class doc comment: it no longer claims "V7 only"; references now flow through native image prompts (`extraImagesNode`). The omniref `--oref`/`--ow` channel remains implemented but is no longer used by the app scene path (a deliberate fallback; cleanup tracked in UO-383).

## Behavior

Default (no call-site overrides) is **neutral**: blank version + no image prompts → identical to before minus the now-absent `--v 7`. The undreamedof app drives the new behavior by setting `version` and populating `extraImagesNode`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)