### PR TITLE
Clear stale blob state when valueHash changes to different content

### DIFF
--- a/source/library/node/blobs/SvBlobNode.js
+++ b/source/library/node/blobs/SvBlobNode.js
@@ -217,6 +217,31 @@
         }
     }
 
+    /**
+     * @description Slot hook fired whenever valueHash changes through any setter
+     * path — including in-place envelope / JSON deserialization, which routes
+     * through Slot.onInstanceSetValue() → setValueHash() → didUpdateSlot(). When
+     * the hash transitions between two DIFFERENT non-null values, this node's
+     * content identity changed underneath a reused instance (e.g. a node updated
+     * in place as its referenced content is swapped). The cached blobValue holds
+     * the OLD hash's bytes, so clear it; the next asyncBlobValue() then lazily
+     * re-loads the bytes for the new hash instead of returning stale bytes.
+     *
+     * The both-non-null-and-different guard is load-bearing: it deliberately
+     * leaves the fresh blob intact during asyncJustSetBlobValue()'s legitimate
+     * sequence (setBlobValue(blob) → setValueHash(null) → setValueHash(hash)),
+     * where each hash transition has a null on one side. It is also a no-op when
+     * the same hash is re-set (didUpdateSlot only fires on an actual change).
+     * @param {?string} oldValue - The previous hash (null if none).
+     * @param {?string} newValue - The new hash (null if cleared).
+     * @category Blob Storage
+     */
+    didUpdateSlotValueHash (oldValue, newValue) {
+        if (oldValue !== null && newValue !== null && oldValue !== newValue) {
+            this.setBlobValue(null); // stale: the cached bytes belong to oldValue's hash
+        }
+    }
+
     async asyncBlobValue () {
         const blob = this.blobValue();
         if (blob) {

--- a/source/library/node/blobs/SvCloudBlobNode.js
+++ b/source/library/node/blobs/SvCloudBlobNode.js
@@ -368,6 +368,28 @@
         };
     }
 
+    /**
+     * @description Extends the base hook (which clears the stale cached blob on
+     * a non-null → different-non-null hash transition) to also reset the cloud
+     * bookkeeping that described the OLD content. Without this, a reused node
+     * keeps hasInCloud === true and a stale downloadUrl for the new hash, so
+     * schedulePushToCloud() would skip uploading the new bytes and asyncPublicUrl()
+     * would hand back a URL for the old content. Any in-flight push for the old
+     * bytes is abandoned. Uses the same both-non-null-and-different guard as the
+     * base, so asyncJustSetBlobValue()'s null-on-one-side sequence is untouched.
+     * @param {?string} oldValue - The previous hash (null if none).
+     * @param {?string} newValue - The new hash (null if cleared).
+     * @category Cloud Storage
+     */
+    didUpdateSlotValueHash (oldValue, newValue) {
+        super.didUpdateSlotValueHash(oldValue, newValue);
+        if (oldValue !== null && newValue !== null && oldValue !== newValue) {
+            this.setHasInCloud(false); // old content's cloud state does not describe the new hash
+            this.setDownloadUrl(null); // old content's URL
+            this.clearPushToCloudPromise(); // abandon any in-flight push of the old bytes
+        }
+    }
+
     async asyncBlobValue (forceRetry = false) {
         const blob = await this.blobValue();
         if (blob) {

--- a/source/library/node/fields/image/SvImageNode.js
+++ b/source/library/node/fields/image/SvImageNode.js
@@ -186,6 +186,24 @@
     }
 
     /**
+     * @description Extends the base/cloud hooks (which clear the stale blob and
+     * cloud bookkeeping on a non-null → different-non-null hash transition) to
+     * also clear the cached publicUrl, which is defined on this subclass and
+     * points at the OLD content. asyncPublicUrl() will recompute it for the new
+     * hash on next access. Same both-non-null-and-different guard as the base,
+     * so the null-on-one-side authoring sequence is left untouched.
+     * @param {?string} oldValue - The previous hash (null if none).
+     * @param {?string} newValue - The new hash (null if cleared).
+     * @category Cloud Storage
+     */
+    didUpdateSlotValueHash (oldValue, newValue) {
+        super.didUpdateSlotValueHash(oldValue, newValue);
+        if (oldValue !== null && newValue !== null && oldValue !== newValue) {
+            this.setPublicUrl(null); // old content's URL — recomputed on next asyncPublicUrl()
+        }
+    }
+
+    /**
      * @description Handles the event when the node is edited.
      * @category Event Handling
      */

--- a/tests/headless/TestBlobHashChange.js
+++ b/tests/headless/TestBlobHashChange.js
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+
+"use strict";
+
+/**
+ * Headless test: stale-blob-on-valueHash-change guard.
+ *
+ * SvBlobNode caches the loaded blob bytes in the transient blobValue slot,
+ * keyed by valueHash. When a node instance is REUSED and its valueHash is
+ * updated in place (the multiplayer case: a guest's node is mutated by
+ * envelope deserialization, hashA → hashB), the cached blobValue still holds
+ * hashA's bytes. Without a guard, asyncBlobValue() returns the stale bytes for
+ * hashB forever (concretely: a chat image preview swapped host-side keeps
+ * rendering the old image on the guest).
+ *
+ * The fix is a slot hook, didUpdateSlotValueHash(oldValue, newValue), that
+ * clears the stale cache when — and only when — the hash transitions between
+ * two DIFFERENT non-null values:
+ *   - SvBlobNode      clears blobValue
+ *   - SvCloudBlobNode also resets hasInCloud / downloadUrl / in-flight push
+ *   - SvImageNode     also clears the cached publicUrl
+ *
+ * The both-non-null-and-different guard must NOT fire during the legitimate
+ * asyncJustSetBlobValue() sequence (setBlobValue(blob) → setValueHash(null) →
+ * setValueHash(computedHash)), where each transition has a null on one side,
+ * nor when the same hash is re-set.
+ *
+ * These checks set slots directly (no network / no store) and drive the real
+ * deserialize path via Slot.onInstanceSetValue(), which is what
+ * SvJsonGroup.setSlotsJson() uses during envelope deserialization.
+ *
+ * Usage (from the strvct root):
+ *   node source/boot/index-builder/ImportsIndexer.js   # if index is stale
+ *   node tests/headless/TestBlobHashChange.js
+ */
+
+const path = require("path");
+const { pathToFileURL } = require("url");
+
+// Boot expects cwd to be the site root (build/_index.json lives there).
+const strvctRoot = path.join(__dirname, "..", "..");
+process.chdir(strvctRoot);
+
+let passed = 0;
+let failed = 0;
+
+function check (condition, message) {
+    if (condition) {
+        passed++;
+        console.log("  \x1b[32m✓\x1b[0m " + message);
+    } else {
+        failed++;
+        console.log("  \x1b[31m✗\x1b[0m " + message);
+    }
+}
+
+async function boot () {
+    const bootFile = (p) => import(pathToFileURL(path.join(strvctRoot, p)).href);
+    await bootFile("source/boot/SvGlobals.js");
+    await bootFile("source/boot/SvPlatform.js");
+    await bootFile("source/boot/StrvctFile.js");
+    await bootFile("source/boot/SvBootLoader.js");
+
+    const SvBootLoader = SvGlobals.get("SvBootLoader");
+    SvBootLoader._bootPath = "source/boot";
+    await SvBootLoader.asyncRun();
+}
+
+const HASH_A = "a".repeat(64);
+const HASH_B = "b".repeat(64);
+
+// A sentinel standing in for loaded blob bytes. We only ever compare it by
+// identity and check whether the hook nulls it, so real bytes are unnecessary
+// (and would trigger async hashing that overwrites the valueHash we control).
+// Set it via the raw ivar so the blobValue setter's own hook does not fire.
+function seedBlob (node, hash) {
+    const fakeBlob = { marker: "bytes-for-" + hash };
+    node._blobValue = fakeBlob; // raw set: bypass setBlobValue()'s recompute hook
+    node.setValueHash(hash); // null → hash: guard leaves the seeded blob intact
+    return fakeBlob;
+}
+
+function testBaseClearsOnHashChange () {
+    console.log("\nSvBlobNode: different non-null hash clears the stale blob");
+
+    const node = SvGlobals.get("SvBlobNode").clone();
+    const blob = seedBlob(node, HASH_A);
+    check(node.blobValue() === blob, "seeded blob present before the hash change");
+
+    node.setValueHash(HASH_B);
+    check(node.valueHash() === HASH_B, "valueHash updated to the new hash");
+    check(node.blobValue() === null, "stale blob cleared on hashA → hashB");
+}
+
+function testCloudResetsBookkeeping () {
+    console.log("\nSvCloudBlobNode: hash change also resets cloud bookkeeping");
+
+    const node = SvGlobals.get("SvCloudBlobNode").clone();
+    const blob = seedBlob(node, HASH_A);
+    node.setHasInCloud(true);
+    node.setDownloadUrl("https://example.com/old-content");
+    check(node.blobValue() === blob && node.hasInCloud() === true, "old content state present before the hash change");
+
+    node.setValueHash(HASH_B);
+    check(node.blobValue() === null, "stale blob cleared");
+    check(node.hasInCloud() === false, "hasInCloud reset (so schedulePushToCloud won't skip the new bytes)");
+    check(node.downloadUrl() === null, "stale downloadUrl cleared");
+}
+
+function testImageResetsPublicUrl () {
+    console.log("\nSvImageNode: hash change also clears the cached publicUrl");
+
+    const node = SvGlobals.get("SvImageNode").clone();
+    seedBlob(node, HASH_A);
+    node.setHasInCloud(true);
+    node.setDownloadUrl("https://example.com/old-download");
+    node.setPublicUrl("https://example.com/old-public");
+    check(node.publicUrl() === "https://example.com/old-public", "old publicUrl present before the hash change");
+
+    node.setValueHash(HASH_B);
+    check(node.blobValue() === null, "stale blob cleared (inherited)");
+    check(node.hasInCloud() === false, "hasInCloud reset (inherited)");
+    check(node.downloadUrl() === null, "downloadUrl cleared (inherited)");
+    check(node.publicUrl() === null, "stale publicUrl cleared");
+}
+
+function testHashToNullKeepsBlob () {
+    console.log("\nGuard: non-null → null keeps the blob (asyncJustSetBlobValue intermediate)");
+
+    const node = SvGlobals.get("SvImageNode").clone();
+    const blob = seedBlob(node, HASH_A);
+
+    node.setValueHash(null);
+    check(node.blobValue() === blob, "blob kept when hash cleared to null (fresh bytes awaiting recompute)");
+}
+
+function testNullToHashKeepsBlob () {
+    console.log("\nGuard: null → non-null keeps the blob (asyncJustSetBlobValue final)");
+
+    const node = SvGlobals.get("SvImageNode").clone();
+    const fakeBlob = { marker: "fresh-bytes" };
+    node._blobValue = fakeBlob; // seed bytes with valueHash still null
+
+    check(node.valueHash() === null, "precondition: valueHash is null");
+    node.setValueHash(HASH_B); // the computed-hash assignment
+    check(node.blobValue() === fakeBlob, "freshly-set blob kept when its computed hash is assigned");
+}
+
+function testSameHashIsNoOp () {
+    console.log("\nGuard: re-setting the SAME hash keeps the blob (no-op)");
+
+    const node = SvGlobals.get("SvImageNode").clone();
+    const blob = seedBlob(node, HASH_A);
+
+    node.setValueHash(HASH_A);
+    check(node.blobValue() === blob, "blob kept when the identical hash is re-set");
+}
+
+function testDeserializePathClears () {
+    console.log("\nDeserialize path: Slot.onInstanceSetValue() (the real bug path) clears the stale blob");
+
+    const node = SvGlobals.get("SvImageNode").clone();
+    seedBlob(node, HASH_A);
+    node.setHasInCloud(true);
+    node.setPublicUrl("https://example.com/old-public");
+
+    // Exact mechanism SvJsonGroup.setSlotsJson() uses for a primitive slot
+    // during envelope deserialization.
+    const slot = node.thisPrototype().slotNamed("valueHash");
+    check(!!slot && typeof (slot.onInstanceSetValue) === "function", "resolved the valueHash slot for the deserialize path");
+    slot.onInstanceSetValue(node, HASH_B);
+
+    check(node.valueHash() === HASH_B, "valueHash updated via onInstanceSetValue");
+    check(node.blobValue() === null, "stale blob cleared through the deserialize path");
+    check(node.hasInCloud() === false, "hasInCloud reset through the deserialize path");
+    check(node.publicUrl() === null, "stale publicUrl cleared through the deserialize path");
+}
+
+async function main () {
+    console.log("TestBlobHashChange: booting strvct…");
+    await boot();
+
+    testBaseClearsOnHashChange();
+    testCloudResetsBookkeeping();
+    testImageResetsPublicUrl();
+    testHashToNullKeepsBlob();
+    testNullToHashKeepsBlob();
+    testSameHashIsNoOp();
+    testDeserializePathClears();
+
+    console.log("\n" + passed + " passed, " + failed + " failed");
+    process.exit(failed === 0 ? 0 : 1);
+}
+
+main().catch((e) => {
+    console.error("BOOT FAILURE:", e);
+    process.exit(1);
+});


### PR DESCRIPTION
Follow-up to #34 (progressive image loading), found during live multiplayer testing of undreamedof.ai#427.

## What's happening

A blob node that gets updated **in place** keeps serving the old content's bytes. Concrete repro: a multiplayer guest's chat-image preview node deserializes an envelope where the host swapped the preview from image 1 (location reference) to image 2 (first grid image). The envelope applies cleanly — `valueHash` now points at image 2 — but `asyncBlobValue()` returns the cached in-memory `blobValue()` **without checking it still matches the hash** (`SvCloudBlobNode.js` asyncBlobValue, first lines), so the guest renders image 1 forever.

The staleness is wider than the bytes: `hasInCloud`/`downloadUrl` (SvCloudBlobNode) and `publicUrl` (SvImageNode) also describe the old content — a reused node with `hasInCloud === true` would even skip `schedulePushToCloud()` for the new bytes.

## The fix

At the classes that own each slot, via the `didUpdateSlotValueHash` hook (fires on the plain-setter path `setSlotsJson` uses during envelope deserialization — verified against `ProtoClass.setSlotValue`/`didUpdateSlot`, no `doesHookSetter` flag needed), guarded to fire **only when the hash transitions between two different non-null values**:

- `SvBlobNode`: clear the cached `blobValue`.
- `SvCloudBlobNode`: also reset `hasInCloud`, `downloadUrl`, and the in-flight push promise.
- `SvImageNode`: also clear `publicUrl` (`hasImage()`/`value()` read it).

The guard is what keeps `asyncJustSetBlobValue`'s legitimate blob-then-compute-hash sequence intact: both of its hash transitions (`hash → null`, `null → computedHash`) have a null on one side, so a freshly-set blob is never cleared. The existing `didUpdateSlotBlobValue` hook guards on `newBlobValue !== null`, so the clear can't cascade into a hash recompute.

One precision on `publicUrl` (surfaced by review audit): unlike `hasInCloud`/`downloadUrl`, `publicUrl` **does cross the cloud envelope** (`isInCloudJson` defaults to `isInJsonSchema`, which that slot sets true), so a guest applying an envelope usually receives the host's new `publicUrl` in the same pass and the clear is moot. The clear matters for the orderings where the hash changes without an accompanying `publicUrl` (direct setter use, partial payloads) — it guarantees no path can serve the old content's URL for the new hash.

## Evidence

New headless suite `tests/headless/TestBlobHashChange.js` — 21/21: the three clears, both preserved blob-then-hash transitions, same-hash no-op, and the real deserialize path (`slot.onInstanceSetValue`, the exact route envelopes ride). `TestImageWellProgressiveProtocol` (17/17) and `TestCategorySlots` (20/20) still green. eslint clean on touched files. **Live multiplayer (undreamedof.ai dev env, paired with undreamedof.ai#427): two consecutive host+guest generation runs green, including the guest's preview correctly swapping location-ref → grid image** — the exact symptom this PR fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
