### PR TITLE
Fix "attempt to double store": don't mutate stored state during a store pass

### DIFF
--- a/source/library/ideal/map/SvAtomicMap.js
+++ b/source/library/ideal/map/SvAtomicMap.js
@@ -212,6 +212,10 @@ SvGlobals.globals().ideal.SvAtomicMap = class SvAtomicMap extends ProtoClass {
         this.setMap(this.snapshot());
         this.setSnapshot(null);
         this.changedKeySet().clear();
+        // Discard async writes staged by the reverted tx — promiseCommit
+        // drains this queue, so leaving them here would leak the reverted
+        // transaction's writes into whatever transaction commits next.
+        this.asyncWriteQueue().clear();
         this.setIsInTx(false);
         this.onCompleteTx();
         return this;

--- a/source/library/node/json/SvSyncableJsonGroup.js
+++ b/source/library/node/json/SvSyncableJsonGroup.js
@@ -313,8 +313,8 @@
                 // not a real model change. touchLocalModified() writes the
                 // STORED localLastModified slot, which would re-dirty this
                 // object mid-pass and trip the pool's double-store guard. Skip
-                // the touch here and log the culprit getter so it can be found.
-                console.warn(this.svTypeId() + " didUpdateNode() fired during a store pass — skipping touchLocalModified() to avoid re-dirtying stored state mid-store. Stack:\n" + new Error().stack);
+                // the touch; the warn's stack identifies the culprit getter.
+                SvObjectPool.warnStorePassMutation(this);
             } else {
                 this.touchLocalModified();
             }

--- a/source/library/node/json/SvSyncableJsonGroup.js
+++ b/source/library/node/json/SvSyncableJsonGroup.js
@@ -307,7 +307,17 @@
         // — those align the timestamps deliberately and shouldn't be
         // immediately re-dirtied by their own slot setters.
         if (this.isFetched() && !this._suppressLocalModifiedTouch) {
-            this.touchLocalModified();
+            if (SvObjectPool.isAnyPoolStoring()) {
+                // Invariant: a didUpdateNode arriving during a store pass is a
+                // side effect of recordForStore reading this subtree's getters,
+                // not a real model change. touchLocalModified() writes the
+                // STORED localLastModified slot, which would re-dirty this
+                // object mid-pass and trip the pool's double-store guard. Skip
+                // the touch here and log the culprit getter so it can be found.
+                console.warn(this.svTypeId() + " didUpdateNode() fired during a store pass — skipping touchLocalModified() to avoid re-dirtying stored state mid-store. Stack:\n" + new Error().stack);
+            } else {
+                this.touchLocalModified();
+            }
         }
         return super.didUpdateNode();
     }

--- a/source/library/node/nodes/syncing/SvSyncableArrayNode.js
+++ b/source/library/node/nodes/syncing/SvSyncableArrayNode.js
@@ -93,7 +93,7 @@
                 // of recordForStore reading getters, not a real model change.
                 // Touching the STORED localLastModified slot here would re-dirty
                 // this object mid-pass and trip the pool's double-store guard.
-                console.warn(this.svTypeId() + " didUpdateNode() fired during a store pass — skipping touchLocalModified() to avoid re-dirtying stored state mid-store. Stack:\n" + new Error().stack);
+                SvObjectPool.warnStorePassMutation(this);
             } else {
                 this.touchLocalModified();
             }

--- a/source/library/node/nodes/syncing/SvSyncableArrayNode.js
+++ b/source/library/node/nodes/syncing/SvSyncableArrayNode.js
@@ -87,7 +87,16 @@
         // setters. See SvSyncableJsonGroup.didSyncToCloud for the
         // longer rationale.
         if (this.hasDoneInit() && !this._suppressLocalModifiedTouch) {
-            this.touchLocalModified();
+            if (SvObjectPool.isAnyPoolStoring()) {
+                // See SvSyncableJsonGroup.didUpdateNode for the full rationale:
+                // a didUpdateNode arriving during a store pass is a side effect
+                // of recordForStore reading getters, not a real model change.
+                // Touching the STORED localLastModified slot here would re-dirty
+                // this object mid-pass and trip the pool's double-store guard.
+                console.warn(this.svTypeId() + " didUpdateNode() fired during a store pass — skipping touchLocalModified() to avoid re-dirtying stored state mid-store. Stack:\n" + new Error().stack);
+            } else {
+                this.touchLocalModified();
+            }
         }
         return super.didUpdateNode();
     }

--- a/source/library/node/storage/base/SvObjectPool.js
+++ b/source/library/node/storage/base/SvObjectPool.js
@@ -994,26 +994,62 @@
      * @returns {void}
      */
     async commitStoreDirtyObjects () {
-        this.logDebug("commitStoreDirtyObjects dirty object count:" + this.dirtyObjects().size);
+        // SvSyncScheduler.processSets() invokes scheduled actions
+        // fire-and-forget: it does not await the promise this method returns.
+        // A second commit can therefore be scheduled and entered while this one
+        // is suspended at an await (promiseBegin / promiseCommit), which would
+        // interleave two kvMap transactions. Guard against re-entry: if a commit
+        // is already in flight, just bail. NOTE: we can't scheduleStore() here —
+        // when re-entered from the scheduler, isSyncingTargetAndMethod() is true
+        // for this exact target/method, so the call would silently no-op. The
+        // in-flight commit reschedules from its finally block instead, which
+        // runs in a later microtask where the scheduler is free again.
+        if (this._isCommitting) {
+            return;
+        }
 
-        if (this.hasDirtyObjects()) {
-            //console.log(this.svType() + " --- commitStoreDirtyObjects ---");
+        this._isCommitting = true;
+        try {
+            this.logDebug("commitStoreDirtyObjects dirty object count:" + this.dirtyObjects().size);
 
-            //this.logDebug("--- commitStoreDirtyObjects begin ---");
-            await this.kvMap().promiseBegin();
-            const storeCount = this.storeDirtyObjects();
-            await this.kvMap().promiseCommit();
-            this.logDebug("--- commitStoreDirtyObjects end --- stored " + storeCount + " objects");
-            this.logDebug("--- commitStoreDirtyObjects total objects: " + this.kvMap().count());
+            if (this.hasDirtyObjects()) {
+                //console.log(this.svType() + " --- commitStoreDirtyObjects ---");
 
-            //this.show("AFTER commitStoreDirtyObjects");
-
-            if (this._forcedDirtyObjectsSet) {
-                if (this._forcedDirtyObjectsSet.size !== 0) {
-                    this.scheduleStore();
-                } else {
-                    this._forcedDirtyObjectsSet = null;
+                //this.logDebug("--- commitStoreDirtyObjects begin ---");
+                await this.kvMap().promiseBegin();
+                let storeCount;
+                try {
+                    storeCount = this.storeDirtyObjects();
+                } catch (e) {
+                    // Self-heal the abandoned transaction: without this, a
+                    // throw mid-pass leaves the kvMap isInTx forever and every
+                    // later commit fails at promiseBegin.
+                    if (this.kvMap().isInTx()) {
+                        this.kvMap().revert();
+                    }
+                    throw e;
                 }
+                await this.kvMap().promiseCommit();
+                this.logDebug("--- commitStoreDirtyObjects end --- stored " + storeCount + " objects");
+                this.logDebug("--- commitStoreDirtyObjects total objects: " + this.kvMap().count());
+
+                //this.show("AFTER commitStoreDirtyObjects");
+
+                if (this._forcedDirtyObjectsSet) {
+                    if (this._forcedDirtyObjectsSet.size !== 0) {
+                        this.scheduleStore();
+                    } else {
+                        this._forcedDirtyObjectsSet = null;
+                    }
+                }
+            }
+        } finally {
+            this._isCommitting = false;
+            // Pick up objects dirtied while this commit was in flight (their
+            // own scheduleStore calls may have been dropped by the re-entrancy
+            // guard above, or by the scheduler's isSyncing check).
+            if (this.hasDirtyObjects()) {
+                this.scheduleStore();
             }
         }
     }

--- a/source/library/node/storage/base/SvObjectPool.js
+++ b/source/library/node/storage/base/SvObjectPool.js
@@ -95,6 +95,53 @@
 
     /**
      * @static
+     * @description Number of store passes (storeDirtyObjects) currently in
+     * progress across all pools. A counter rather than a boolean so nested or
+     * concurrent pools compose correctly. Since storeDirtyObjects() runs fully
+     * synchronously, this reliably brackets the entire pass.
+     * @returns {Number}
+     * @category Storing
+     */
+    static storingPassCount () {
+        return this._storingPassCount || 0;
+    }
+
+    /**
+     * @static
+     * @description True while any pool's storeDirtyObjects() pass is in
+     * progress. Model objects can consult this to tell an incidental mutation
+     * caused by serialization (getters read during recordForStore) apart from
+     * a genuine model change.
+     * @returns {Boolean}
+     * @category Storing
+     */
+    static isAnyPoolStoring () {
+        return this.storingPassCount() > 0;
+    }
+
+    /**
+     * @static
+     * @description Marks the beginning of a store pass. Called from
+     * storeDirtyObjects(). Always paired with endStoringPass() in a finally.
+     * @returns {void}
+     * @category Storing
+     */
+    static beginStoringPass () {
+        this._storingPassCount = this.storingPassCount() + 1;
+    }
+
+    /**
+     * @static
+     * @description Marks the end of a store pass.
+     * @returns {void}
+     * @category Storing
+     */
+    static endStoringPass () {
+        this._storingPassCount = this.storingPassCount() - 1;
+    }
+
+    /**
+     * @static
      * @description Notifies all open pools when an object's puuid changes.
      * This allows all pools tracking an object to update their internal mappings.
      * @param {Object} obj - The object whose puuid changed
@@ -982,41 +1029,51 @@
 
         let totalStoreCount = 0;
         this.setStoringPids(new Set());
+        SvObjectPool.beginStoringPass();
 
-        for (;;) { // easier to express clearly than do/while in this case
-            let thisLoopStoreCount = 0;
-            const dirtyBucket = this.dirtyObjects();
-            this.setDirtyObjects(new Map());
+        try {
+            for (;;) { // easier to express clearly than do/while in this case
+                let thisLoopStoreCount = 0;
+                const dirtyBucket = this.dirtyObjects();
+                this.setDirtyObjects(new Map());
 
-            dirtyBucket.forEachKV((puuid, obj) => {
-                //console.log("  storing pid " + puuid);
+                dirtyBucket.forEachKV((puuid, obj) => {
+                    //console.log("  storing pid " + puuid);
 
-                if (this.storingPids().has(puuid)) {
-                    const msg = "ERROR: attempt to double store " + obj.svTypeId();
-                    console.log(msg);
-                    throw new Error(msg);
+                    if (this.storingPids().has(puuid)) {
+                        const msg = "ERROR: attempt to double store " + obj.svTypeId();
+                        console.log(msg);
+                        throw new Error(msg);
+                    }
+
+                    this.storingPids().add(puuid);
+
+                    if (this._forcedDirtyObjectsSet && this._forcedDirtyObjectsSet.has(obj)) {
+                        this._forcedDirtyObjectsSet.delete(obj);
+                    }
+
+                    this.storeObject(obj);
+
+                    thisLoopStoreCount ++;
+                });
+
+                if (thisLoopStoreCount === 0) {
+                    break;
                 }
 
-                this.storingPids().add(puuid);
-
-                if (this._forcedDirtyObjectsSet && this._forcedDirtyObjectsSet.has(obj)) {
-                    this._forcedDirtyObjectsSet.delete(obj);
-                }
-
-                this.storeObject(obj);
-
-                thisLoopStoreCount ++;
-            });
-
-            if (thisLoopStoreCount === 0) {
-                break;
+                totalStoreCount += thisLoopStoreCount;
+                //this.logDebug(() => "totalStoreCount: " + totalStoreCount);
             }
-
-            totalStoreCount += thisLoopStoreCount;
-            //this.logDebug(() => "totalStoreCount: " + totalStoreCount);
+        } finally {
+            // Always clear the storing state, even if serialization threw
+            // mid-pass. Without this, an exception would leave storingPids
+            // populated forever, poisoning the pool: every later
+            // addDirtyObject() of an already-stored pid would raise a spurious
+            // double-store error.
+            SvObjectPool.endStoringPass();
+            this.setStoringPids(null);
         }
 
-        this.setStoringPids(null);
         return totalStoreCount;
     }
 

--- a/source/library/node/storage/base/SvObjectPool.js
+++ b/source/library/node/storage/base/SvObjectPool.js
@@ -142,6 +142,20 @@
 
     /**
      * @static
+     * @description Logs a warning (with a stack) that a stored-state mutation
+     * was suppressed because it arrived during a store pass — i.e. it was a
+     * side effect of recordForStore reading getters, not a real model change.
+     * The stack identifies the culprit getter so it can be fixed at the source.
+     * @param {Object} anObject - the object whose mutation was suppressed
+     * @returns {void}
+     * @category Storing
+     */
+    static warnStorePassMutation (anObject) {
+        console.warn(anObject.svTypeId() + " mutation suppressed during a store pass — serialization must not write stored state. Stack:\n" + new Error().stack);
+    }
+
+    /**
+     * @static
      * @description Notifies all open pools when an object's puuid changes.
      * This allows all pools tracking an object to update their internal mappings.
      * @param {Object} obj - The object whose puuid changed

--- a/tests/headless/TestStorePassMutation.js
+++ b/tests/headless/TestStorePassMutation.js
@@ -176,6 +176,64 @@ async function testGenuineLoopStillTripsAndPoolRecovers () {
     check(SvObjectPool.isAnyPoolStoring() === false, "isAnyPoolStoring() false even after a throw");
 }
 
+async function testCommitReentrancyGuard () {
+    console.log("\nRe-entrancy guard: a concurrent commit does not interleave a second kvMap transaction");
+
+    const pool = newPool();
+    const group = makeSyncableGroup();
+    pool.addActiveObject(group);
+    pool.dirtyObjects().set(group.puuid(), group);
+
+    const kvMap = pool.kvMap();
+    let beginCount = 0;
+    let commitCount = 0;
+    let releaseCommit = null;
+    const commitGate = new Promise((resolve) => { releaseCommit = resolve; });
+
+    const realBegin = kvMap.promiseBegin.bind(kvMap);
+    const realCommit = kvMap.promiseCommit.bind(kvMap);
+    kvMap.promiseBegin = async function () {
+        beginCount++;
+        return realBegin();
+    };
+    kvMap.promiseCommit = async function () {
+        commitCount++;
+        if (commitCount === 1) {
+            await commitGate; // hang the first commit AFTER storeDirtyObjects() has run
+        }
+        return realCommit();
+    };
+
+    const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+    // First commit: begins, stores the group, then suspends inside promiseCommit.
+    const p1 = pool.commitStoreDirtyObjects();
+    await tick();
+
+    check(beginCount === 1, "first commit began exactly one transaction");
+    check(pool._isCommitting === true, "first commit is marked in-flight");
+
+    // A new object is dirtied while the first commit is suspended mid-transaction.
+    const late = makeSyncableGroup();
+    pool.addActiveObject(late);
+    pool.dirtyObjects().set(late.puuid(), late);
+
+    // Second commit attempt while the first is still in flight.
+    await pool.commitStoreDirtyObjects();
+    check(beginCount === 1, "second concurrent commit did NOT begin a second transaction");
+    check(!kvMap.hasKey(late.puuid()), "object dirtied during the in-flight commit not yet stored");
+
+    // Release the first commit and let it finish.
+    releaseCommit();
+    await p1;
+    check(pool._isCommitting === false, "in-flight flag cleared after the first commit completes");
+
+    // A follow-up commit stores the object that arrived during the in-flight commit.
+    await pool.commitStoreDirtyObjects();
+    check(beginCount === 2, "follow-up commit began a second transaction");
+    check(kvMap.hasKey(late.puuid()), "object dirtied during the in-flight commit is stored by the follow-up commit");
+}
+
 async function main () {
     console.log("TestStorePassMutation: booting strvct…");
     await boot();
@@ -186,6 +244,7 @@ async function main () {
 
     await testTouchSuppressedDuringStorePass();
     await testGenuineLoopStillTripsAndPoolRecovers();
+    await testCommitReentrancyGuard();
 
     console.log("\n" + passed + " passed, " + failed + " failed");
     process.exit(failed === 0 ? 0 : 1);

--- a/tests/headless/TestStorePassMutation.js
+++ b/tests/headless/TestStorePassMutation.js
@@ -234,6 +234,25 @@ async function testCommitReentrancyGuard () {
     check(kvMap.hasKey(late.puuid()), "object dirtied during the in-flight commit is stored by the follow-up commit");
 }
 
+async function testRevertDiscardsStagedAsyncWrites () {
+    console.log("\nSvAtomicMap.revert(): async writes staged by the reverted tx do not leak into the next commit");
+
+    const kv = newPool().kvMap();
+
+    await kv.promiseBegin();
+    kv.atPut("syncKey", "syncValue");
+    kv.appendAsyncWriteKvPromise(Promise.resolve(["asyncKey", "asyncValue"]));
+    kv.revert();
+    check(kv.isInTx() === false, "revert closes the transaction");
+    check(!kv.hasKey("syncKey"), "revert discards the synchronous write");
+
+    // A later, unrelated transaction must not pick up the reverted tx's
+    // staged async write (promiseCommit drains asyncWriteQueue).
+    await kv.promiseBegin();
+    await kv.promiseCommit();
+    check(!kv.hasKey("asyncKey"), "reverted tx's staged async write does not leak into the next commit");
+}
+
 async function main () {
     console.log("TestStorePassMutation: booting strvct…");
     await boot();
@@ -245,6 +264,7 @@ async function main () {
     await testTouchSuppressedDuringStorePass();
     await testGenuineLoopStillTripsAndPoolRecovers();
     await testCommitReentrancyGuard();
+    await testRevertDiscardsStagedAsyncWrites();
 
     console.log("\n" + passed + " passed, " + failed + " failed");
     process.exit(failed === 0 ? 0 : 1);

--- a/tests/headless/TestStorePassMutation.js
+++ b/tests/headless/TestStorePassMutation.js
@@ -1,0 +1,197 @@
+#!/usr/bin/env node
+
+"use strict";
+
+/**
+ * Headless test: serialization must not mutate stored state (double-store fix).
+ *
+ * SvObjectPool.storeDirtyObjects() runs a synchronous pass over the dirty
+ * objects: for each it adds the puuid to storingPids and serializes it via
+ * recordForStore(), which invokes real slot getters. SvSyncableJsonGroup
+ * touches its STORED localLastModified slot in didUpdateNode() whenever any
+ * descendant bubbles an update up the parent chain. If a descendant getter
+ * fires didUpdateNode() on the group mid-pass, the group is re-marked dirty;
+ * on the next sweep the pool finds its puuid both in the fresh dirty map and
+ * in storingPids and throws "attempt to double store". Because
+ * storeDirtyObjects() had no try/finally, that throw also left storingPids set
+ * forever, poisoning the pool.
+ *
+ * The fix:
+ *   - SvObjectPool exposes a static isAnyPoolStoring() predicate, bracketed by
+ *     begin/endStoringPass() around the (synchronous) store pass.
+ *   - SvSyncableJsonGroup.didUpdateNode() skips touchLocalModified() while a
+ *     store pass is in progress (and warns with a stack so the culprit getter
+ *     is identifiable), so serialization no longer mutates stored state.
+ *   - storeDirtyObjects() wraps the pass in try/finally so a throw can no
+ *     longer poison the pool (storingPids is always reset).
+ *
+ * Commit 2 additionally guards commitStoreDirtyObjects() against re-entry so a
+ * fire-and-forget second commit scheduled while the first is suspended at an
+ * await cannot interleave two kvMap transactions.
+ *
+ * The pool is driven directly with its default synchronous SvAtomicMap kvMap;
+ * the culprit getter is simulated by overriding recordForStore() on a child
+ * instance to fire the mid-pass mutation through the real
+ * SvSyncableJsonGroup.didUpdateNode() code path.
+ *
+ * Usage (from the strvct root):
+ *   node source/boot/index-builder/ImportsIndexer.js   # if index is stale
+ *   node tests/headless/TestStorePassMutation.js
+ */
+
+const path = require("path");
+const { pathToFileURL } = require("url");
+
+// Boot expects cwd to be the site root (build/_index.json lives there).
+const strvctRoot = path.join(__dirname, "..", "..");
+process.chdir(strvctRoot);
+
+let passed = 0;
+let failed = 0;
+
+function check (condition, message) {
+    if (condition) {
+        passed++;
+        console.log("  \x1b[32m✓\x1b[0m " + message);
+    } else {
+        failed++;
+        console.log("  \x1b[31m✗\x1b[0m " + message);
+    }
+}
+
+async function boot () {
+    const bootFile = (p) => import(pathToFileURL(path.join(strvctRoot, p)).href);
+    await bootFile("source/boot/SvGlobals.js");
+    await bootFile("source/boot/SvPlatform.js");
+    await bootFile("source/boot/StrvctFile.js");
+    await bootFile("source/boot/SvBootLoader.js");
+
+    const SvBootLoader = SvGlobals.get("SvBootLoader");
+    SvBootLoader._bootPath = "source/boot";
+    await SvBootLoader.asyncRun();
+}
+
+// --- helpers -------------------------------------------------------------
+
+// A pool with its default (synchronous) SvAtomicMap kvMap, which is open by
+// default. No blob store or async open needed for these checks.
+function newPool () {
+    const SvObjectPool = SvGlobals.get("SvObjectPool");
+    return SvObjectPool.clone();
+}
+
+// A fully-fetched syncable group standing in for a stored document root.
+function makeSyncableGroup () {
+    const group = SvGlobals.get("SvSyncableJsonGroup").clone();
+    // fetchState defaults to "fetched"
+    return group;
+}
+
+// A plain stored group whose serialization fires a caller-supplied side effect
+// on a target node — the stand-in for a descendant getter that bubbles a
+// didUpdateNode() up to the group while recordForStore() reads it mid-pass.
+function makeSerializingChild (targetNode, sideEffectFn) {
+    const child = SvGlobals.get("SvJsonGroup").clone();
+    const superRecordForStore = child.recordForStore.bind(child);
+    child.recordForStore = function (aStore) {
+        sideEffectFn(targetNode);
+        return superRecordForStore(aStore);
+    };
+    return child;
+}
+
+// Register both objects as active/observed, then seed the dirty bucket with the
+// CHILD ordered BEFORE the group. This ordering is what reproduces the bug: the
+// group is not yet in storingPids when the child's serialization touches it, so
+// the re-dirty slips into the fresh dirty map and re-appears next sweep.
+function primeDirty (pool, child, group) {
+    pool.addActiveObject(child);
+    pool.addActiveObject(group);
+    pool.dirtyObjects().set(child.puuid(), child);
+    pool.dirtyObjects().set(group.puuid(), group);
+}
+
+// --- tests ---------------------------------------------------------------
+
+async function testTouchSuppressedDuringStorePass () {
+    console.log("\nStore pass: a group didUpdateNode() mid-serialize does not re-dirty or throw");
+
+    const SvObjectPool = SvGlobals.get("SvObjectPool");
+    const pool = newPool();
+    const group = makeSyncableGroup();
+    const child = makeSerializingChild(group, (g) => g.didUpdateNode());
+
+    group.setLocalLastModified(12345); // known baseline
+    primeDirty(pool, child, group);
+    const baseline = group.localLastModified();
+
+    let threw = null;
+    try {
+        await pool.commitStoreDirtyObjects();
+    } catch (e) {
+        threw = e;
+    }
+
+    check(threw === null, "commit completed WITHOUT an 'attempt to double store' throw" + (threw ? " (threw: " + threw.message + ")" : ""));
+    check(group.localLastModified() === baseline, "group localLastModified unchanged across the store pass (serialization did not mutate stored state)");
+    check(pool.storingPids() === null, "pool.storingPids() === null after the pass");
+    check(SvObjectPool.isAnyPoolStoring() === false, "SvObjectPool.isAnyPoolStoring() === false after the pass");
+    check(pool.kvMap().hasKey(group.puuid()), "the group was actually stored");
+
+    // Pool not poisoned: mutate the group again and commit; it stores cleanly.
+    group.setCloudLastModified(99999);
+    let threw2 = null;
+    try {
+        await pool.commitStoreDirtyObjects();
+    } catch (e) {
+        threw2 = e;
+    }
+    check(threw2 === null, "a second commit after the pass stores cleanly (pool not poisoned)");
+}
+
+async function testGenuineLoopStillTripsAndPoolRecovers () {
+    console.log("\nRegression guard: a genuine mid-pass re-dirty (different stored slot) still trips the double-store guard");
+
+    const SvObjectPool = SvGlobals.get("SvObjectPool");
+    const pool = newPool();
+    const group = makeSyncableGroup();
+    // Mutate a DIFFERENT stored slot (cloudLastModified) mid-pass — a real
+    // model change the fix does NOT suppress. The pool's loop/double-store
+    // detection must still fire, proving we didn't disable it.
+    let n = 0;
+    const child = makeSerializingChild(group, (g) => g.setCloudLastModified(1000 + (n++)));
+    primeDirty(pool, child, group);
+
+    let threw = null;
+    try {
+        await pool.commitStoreDirtyObjects();
+    } catch (e) {
+        threw = e;
+    }
+
+    check(threw !== null && /double store/i.test(threw.message), "genuine mid-pass re-dirty still throws a double-store error");
+    // try/finally hardening: even though storeObject threw, the pool's storing
+    // state is cleared, so the pool is not left poisoned.
+    check(pool.storingPids() === null, "storingPids reset to null even after a throw (try/finally hardening)");
+    check(SvObjectPool.isAnyPoolStoring() === false, "isAnyPoolStoring() false even after a throw");
+}
+
+async function main () {
+    console.log("TestStorePassMutation: booting strvct…");
+    await boot();
+
+    // Isolate the pool logic from the scheduler's fire-and-forget auto-commits;
+    // we drive commitStoreDirtyObjects() explicitly.
+    SvGlobals.get("SvSyncScheduler").shared().pause();
+
+    await testTouchSuppressedDuringStorePass();
+    await testGenuineLoopStillTripsAndPoolRecovers();
+
+    console.log("\n" + passed + " passed, " + failed + " failed");
+    process.exit(failed === 0 ? 0 : 1);
+}
+
+main().catch((e) => {
+    console.error("BOOT FAILURE:", e);
+    process.exit(1);
+});


### PR DESCRIPTION
## Problem

Intermittent crash during persistence commits:

```
Error: ERROR: attempt to double store <SvSyncableJsonGroup subclass instance>
    at SvPersistentObjectPool.storeDirtyObjects
    at SvPersistentObjectPool.commitStoreDirtyObjects
```

`storeDirtyObjects()` serializes each dirty object via `recordForStore()`, which invokes real slot getter methods. `SvSyncableJsonGroup.didUpdateNode()` (and its sibling `SvSyncableArrayNode`) touches the **stored** `localLastModified` slot whenever any descendant bubbles an update. If a descendant getter fires `didUpdateNode()` mid-pass — before the group's own turn in the dirty bucket — the group is re-marked dirty inside the pass, and the next sweep finds it both in the fresh dirty map and in `storingPids` → throw. Worse, the throw skipped `setStoringPids(null)`, permanently poisoning the pool: every later dirtying of an already-stored pid threw too.

## Fix

**Commit 1 — serialization must not mutate stored state**
- `SvObjectPool`: static `isAnyPoolStoring()` predicate (counter bracketing the synchronous store pass, incremented/decremented in `storeDirtyObjects`).
- `SvSyncableJsonGroup.didUpdateNode()` / `SvSyncableArrayNode.didUpdateNode()`: skip `touchLocalModified()` while a store pass is running — a `didUpdateNode` in that window is a serialization side effect, not a real model change. A `console.warn` with a stack identifies the culprit getter so it can be fixed at the source.
- `storeDirtyObjects()`: try/finally so a mid-pass throw resets `storingPids` instead of poisoning the pool.

**Commit 2 — commit re-entrancy + tx self-heal**
- `SvSyncScheduler.processSets()` doesn't await async actions, so a second `commitStoreDirtyObjects()` could interleave a second kvMap transaction while the first was suspended at an await. Added an `_isCommitting` guard; the in-flight commit reschedules from its `finally` when dirty objects remain (a re-entrant `scheduleStore()` would no-op — `isSyncingTargetAndMethod()` is true at that moment).
- On a mid-pass throw, `revert()` the open kvMap tx before rethrowing so the map doesn't stay `isInTx` forever.

## Testing

New headless test `tests/headless/TestStorePassMutation.js` (16 checks): reproduces the double-store via a child whose serialization fires `didUpdateNode()` on its group mid-pass; asserts no throw, `localLastModified` unchanged across the pass, `storingPids`/counter reset, pool usable afterwards; asserts a *genuine* mid-pass mutation of a different stored slot **still trips** the double-store guard (loop detection preserved); asserts the throw path resets state; asserts a concurrent commit begins no second transaction and mid-commit dirties are stored by the follow-up commit.

Verified negatively: with the `didUpdateNode` guard temporarily disabled, the test throws the exact "attempt to double store" error.

Pre-existing headless suites still green: TestBlobHashChange 21/0, TestCategorySlots 20/0, TestJsonPatchErrors 14/0, TestObjectMessagingPrep 18/0. ESLint clean.

Caveat: reproduced and verified headlessly; not yet confirmed against the original in-browser repro (the warn log will identify the real culprit getter when it next occurs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)