### PR TITLE
Lazy-slot materialization is store-neutral (fixes spurious cloud touches; underlies #36)

### DIFF
--- a/source/library/ideal/proto/ProtoClass.js
+++ b/source/library/ideal/proto/ProtoClass.js
@@ -375,19 +375,6 @@
         }
         {
             /**
-             * @member {boolean} isMaterializingLazySlot - True while a lazy slot's
-             * stored value is being written through its setter on first access.
-             * SvStorableNode.didUpdateSlot consults this to skip didMutate():
-             * materialization is not a semantic change, so it must fire the
-             * normal update hooks (view sync) without marking the object dirty
-             * or notifying mutation observers.
-             * @category Slots
-             */
-            const slot = this.newSlot("isMaterializingLazySlot", false);
-            slot.setSlotType("Boolean");
-        }
-        {
-            /**
              * @member {Set} protocols - A set of protocols.
              */
             const slot = this.newSlot("protocols", new Set());

--- a/source/library/ideal/proto/Slot.js
+++ b/source/library/ideal/proto/Slot.js
@@ -159,6 +159,18 @@ SvGlobals.globals().ideal.Slot = (class Slot extends Object {
         return null;
     }
 
+    /**
+     * @description Marks the slot lazy: loadFromRecord leaves an SvStoreRef
+     * placeholder in the slot and the value materializes on first getter
+     * access. CONTRACT for hook authors: a didUpdateSlot<Name> hook on a lazy
+     * slot may receive an SvStoreRef as oldValue during the materialization
+     * write-back — that transition means "this write is a load, not an edit"
+     * (consumers derive store-neutrality from it). Treat an SvStoreRef
+     * oldValue as "there was no previous live value".
+     * @param {Boolean} aBool
+     * @returns {Slot}
+     * @category Lazy Loading
+     */
     setIsLazy (aBool) {
         this._isLazy = aBool;
         if (aBool) {
@@ -1099,20 +1111,21 @@ SvGlobals.globals().ideal.Slot = (class Slot extends Object {
     /**
      * @static
      * @category StoreRefs for lazy slots
-     * @description True while any lazy slot's stub is being written back into
-     * its slot (the setter call in onInstanceMaterializeLazySlot). During that
-     * synchronous window, a didUpdateNode bubble can reach OBJECTS OTHER THAN
-     * the materializing one (ancestors up the parent chain), whose per-instance
-     * isMaterializingLazySlot flag is false — so cross-object echo filtering
-     * needs this globally visible signal (single-threaded JS attributes
-     * anything inside the window to the materialization). Consumers must
-     * filter NARROWLY: only side effects that are pure echoes of loading may
-     * consult this — currently just SvSyncable*.touchLocalModified (the cloud
-     * timestamp; loading is not a local modification). Dirty-marking is NOT
-     * filtered globally — objects genuinely created or changed by hooks during
+     * @description True while any lazy slot's SvStoreRef is being written
+     * back into its slot (the setter call in onInstanceMaterializeLazySlot).
+     * The didUpdateNode bubble can reach OBJECTS OTHER THAN the materializing
+     * one (ancestors up the parent chain), and the bubble carries no oldValue
+     * to derive from — so cross-object echo filtering needs this globally
+     * visible signal (single-threaded JS attributes anything inside the
+     * window to the materialization). Consumers must filter NARROWLY: only
+     * side effects that are pure echoes of loading may consult this —
+     * currently just SvSyncable*.touchLocalModified (the cloud timestamp;
+     * loading is not a local modification). Dirty-marking is NOT filtered by
+     * this counter — objects genuinely created or changed by hooks during
      * someone else's materialization must still be stored; the materializing
-     * instance's own write-back echo is filtered per-instance in
-     * SvStorableNode.didMutate instead.
+     * instance's own write-back echo is DERIVED instead, from the SvStoreRef
+     * → value transition visible to didUpdateSlot (see
+     * SvStorableNode.didUpdateSlot).
      * A counter, not a boolean, so nested materializations (writing one value
      * can trigger a getter that materializes another) compose correctly.
      * @returns {Boolean}
@@ -1143,18 +1156,21 @@ SvGlobals.globals().ideal.Slot = (class Slot extends Object {
      * object and writes it through the setter, so didUpdateSlot hooks and view
      * sync fire like any other change. Materialization is a no-op with respect
      * to the store but an event with respect to the UI, so exactly two echo
-     * filters apply during the write-back window: the materializing instance's
-     * own didMutate is skipped (per-instance flag, SvStorableNode.didMutate),
-     * and SvSyncable ancestors reached by the didUpdateNode bubble skip their
-     * localLastModified touch (static counter, see
+     * filters apply during the write-back: the materializing instance's own
+     * dirty-marking is skipped by DERIVATION — the SvStoreRef stays in the
+     * slot until the setter write, so didUpdateSlot sees the SvStoreRef →
+     * value transition and knows this is a load (SvStorableNode.didUpdateSlot,
+     * SvNode.didUpdateSlotSubnodes) — and SvSyncable ancestors reached by the
+     * didUpdateNode bubble (which carries no oldValue) skip their
+     * localLastModified touch via the static counter (see
      * isMaterializingAnyLazySlot). Everything else — including objects
      * genuinely created or changed by hooks inside the window — dirties and
      * stores normally, as do real load-time changes (finalInit repairs during
-     * unref, didMaterializeSlot hygiene) which run OUTSIDE the bracket.
+     * unref, didMaterializeSlot hygiene) which run OUTSIDE the write-back.
      */
     onInstanceMaterializeLazySlot (anInstance) {
         const storeRef = this.onInstanceRawGetValue(anInstance);
-        assert(storeRef instanceof SvStoreRef, "onInstanceMaterializeLazySlot called without a stub in slot '" + this.name() + "'");
+        assert(storeRef instanceof SvStoreRef, "onInstanceMaterializeLazySlot called without an SvStoreRef in slot '" + this.name() + "'");
 
         // If this materialization initiates the load cycle (the common case:
         // a getter touched after boot), drain the pool's loadingPids so
@@ -1171,30 +1187,25 @@ SvGlobals.globals().ideal.Slot = (class Slot extends Object {
             pool.didInitLoadingPids();
         }
 
-        // Clear the stub RAW before the setter write: didUpdateSlot hooks
-        // receive oldValue and assume its type (e.g. didUpdateSlotSubnodes
-        // calls oldValue.removeMutationObserver) — they must see the normal
-        // null → value load transition, never the stub.
-        this.onInstanceRawSetValue(anInstance, null);
-
-        anInstance.setIsMaterializingLazySlot(true);
+        // The SvStoreRef deliberately STAYS in the slot until the setter
+        // write below, so didUpdateSlot receives it as oldValue — the
+        // unforgeable, data-carried evidence that this write is a LOAD
+        // rather than an edit. Consumers derive the classification from the
+        // transition itself: SvStorableNode.didUpdateSlot skips didMutate,
+        // and SvNode.didUpdateSlotSubnodes skips both the
+        // removeMutationObserver call and the store half of
+        // didChangeSubnodeList. Contract: any didUpdateSlot<Name> hook on a
+        // LAZY slot may receive an SvStoreRef as oldValue (see setIsLazy).
+        // If the setter throws before the write lands, the SvStoreRef is
+        // still in place, so the next access simply retries.
         Slot.beginLazySlotMaterialization();
         try {
             this.onInstanceSetValue(anInstance, obj);
-        } catch (e) {
-            // Transactional restore: the stub was cleared above, so a throwing
-            // setter would otherwise leave the slot permanently null — the
-            // store still has the record, but no retry path remains (the
-            // getter only materializes stubs). Put the stub back so the next
-            // access retries, and rethrow — hide nothing.
-            this.onInstanceRawSetValue(anInstance, storeRef);
-            throw e;
         } finally {
             Slot.endLazySlotMaterialization();
-            anInstance.setIsMaterializingLazySlot(false);
         }
 
-        // After the flag clears: hook edits (e.g. hygiene passes a class
+        // After the write-back: hook edits (e.g. hygiene passes a class
         // deferred from finalInit) are real mutations and mark dirty normally.
         if (anInstance.didMaterializeSlot) {
             anInstance.didMaterializeSlot(this);

--- a/source/library/ideal/proto/Slot.js
+++ b/source/library/ideal/proto/Slot.js
@@ -1097,12 +1097,54 @@ SvGlobals.globals().ideal.Slot = (class Slot extends Object {
     }
 
     /**
+     * @static
+     * @category StoreRefs for lazy slots
+     * @description True while any lazy slot's stub is being written back into
+     * its slot (the setter call in onInstanceMaterializeLazySlot). During that
+     * synchronous window, every didUpdateSlot/didUpdateNode that fires —
+     * anywhere, at any depth of the bubble — was caused by the materialization
+     * (single-threaded JS: nothing else can run). Store-facing reactions
+     * consult this to stay neutral: materialization is NOT a mutation with
+     * respect to the store (the store already holds exactly the value being
+     * loaded), but it IS an event with respect to the UI (views must re-sync)
+     * — so view-facing hooks fire normally while SvObjectPool skips
+     * addDirtyObject and SvSyncable* skip the localLastModified touch.
+     * A counter, not a boolean, so nested materializations (writing one value
+     * can trigger a getter that materializes another) compose correctly.
+     * @returns {Boolean}
+     */
+    static isMaterializingAnyLazySlot () {
+        return (this._materializingLazySlotCount || 0) > 0;
+    }
+
+    /**
+     * @static
+     * @category StoreRefs for lazy slots
+     */
+    static beginLazySlotMaterialization () {
+        this._materializingLazySlotCount = (this._materializingLazySlotCount || 0) + 1;
+    }
+
+    /**
+     * @static
+     * @category StoreRefs for lazy slots
+     */
+    static endLazySlotMaterialization () {
+        this._materializingLazySlotCount = this._materializingLazySlotCount - 1;
+    }
+
+    /**
      * @category StoreRefs for lazy slots
      * @description Resolves a lazy slot's SvStoreRef stub into the real stored
      * object and writes it through the setter, so didUpdateSlot hooks and view
-     * sync fire like any other change — but with didMutate suppressed
-     * (materialization is not a semantic change; the object must not be marked
-     * dirty and mutation observers must not be notified).
+     * sync fire like any other change. Store-facing reactions are suppressed
+     * for the write-back window via the static materialization counter (see
+     * isMaterializingAnyLazySlot): didMutate still FIRES normally — mutation
+     * observers stay honest — but SvObjectPool declines to mark dirty, and
+     * SvSyncable groups decline to touch their cloud timestamp, because
+     * materialization is a no-op with respect to the store. Real load-time
+     * changes (finalInit repairs during unref, didMaterializeSlot hygiene)
+     * run OUTSIDE the bracket and dirty normally.
      */
     onInstanceMaterializeLazySlot (anInstance) {
         const storeRef = this.onInstanceRawGetValue(anInstance);
@@ -1130,9 +1172,19 @@ SvGlobals.globals().ideal.Slot = (class Slot extends Object {
         this.onInstanceRawSetValue(anInstance, null);
 
         anInstance.setIsMaterializingLazySlot(true);
+        Slot.beginLazySlotMaterialization();
         try {
             this.onInstanceSetValue(anInstance, obj);
+        } catch (e) {
+            // Transactional restore: the stub was cleared above, so a throwing
+            // setter would otherwise leave the slot permanently null — the
+            // store still has the record, but no retry path remains (the
+            // getter only materializes stubs). Put the stub back so the next
+            // access retries, and rethrow — hide nothing.
+            this.onInstanceRawSetValue(anInstance, storeRef);
+            throw e;
         } finally {
+            Slot.endLazySlotMaterialization();
             anInstance.setIsMaterializingLazySlot(false);
         }
 

--- a/source/library/ideal/proto/Slot.js
+++ b/source/library/ideal/proto/Slot.js
@@ -55,6 +55,7 @@ SvGlobals.globals().ideal.Slot = (class Slot extends Object {
         this.simpleNewSlot("methodForUndefinedGet", null);
         this.simpleNewSlot("methodForOnFinalized", null);
         this.simpleNewSlot("methodForShouldStoreSlot", null);
+        this.simpleNewSlot("methodForFailedLazyLoad", null); // for lazy slots — see onInstanceFailedLazyLoad
         //this.simpleNewSlot("methodNameCache", null)
 
         // getter
@@ -167,6 +168,11 @@ SvGlobals.globals().ideal.Slot = (class Slot extends Object {
      * write-back — that transition means "this write is a load, not an edit"
      * (consumers derive store-neutrality from it). Treat an SvStoreRef
      * oldValue as "there was no previous live value".
+     * FAILURE semantics: if the record is missing from the pool, the getter
+     * returns null (or the owner's onFailedLazyLoadSlot<Name> hook fallback),
+     * the SvStoreRef stays in the slot (retry-on-next-access, rate-limited
+     * by a negative cache on the ref), and nothing is written through the
+     * setter. See onInstanceMaterializeLazySlot / onInstanceFailedLazyLoad.
      * @param {Boolean} aBool
      * @returns {Slot}
      * @category Lazy Loading
@@ -899,6 +905,7 @@ SvGlobals.globals().ideal.Slot = (class Slot extends Object {
         this.setMethodForUndefinedGet("onUndefinedGet" + n); // for lazy slots
         this.setMethodForOnFinalized("onFinalizedSlot" + n); // for weak slots
         this.setMethodForShouldStoreSlot("shouldStoreSlot" + n); // for weak slots
+        this.setMethodForFailedLazyLoad("onFailedLazyLoadSlot" + n); // for lazy slots
         return this;
     }
 
@@ -1176,6 +1183,13 @@ SvGlobals.globals().ideal.Slot = (class Slot extends Object {
         const storeRef = this.onInstanceRawGetValue(anInstance);
         assert(storeRef instanceof SvStoreRef, "onInstanceMaterializeLazySlot called without an SvStoreRef in slot '" + this.name() + "'");
 
+        // Negative cache: a ref that failed recently declines to hit the pool
+        // again (UI sync hammers getters every render pass), but the owner
+        // hook still runs so a fallback doesn't flicker between accesses.
+        if (!storeRef.canAttemptNow()) {
+            return this.onInstanceFailedLazyLoad(anInstance, storeRef);
+        }
+
         // If this materialization initiates the load cycle (the common case:
         // a getter touched after boot), drain the pool's loadingPids so
         // didLoadFromStore runs on the subtree before we return — callers
@@ -1186,6 +1200,25 @@ SvGlobals.globals().ideal.Slot = (class Slot extends Object {
         const initiatesLoadCycle = !pool.isFinalizing() && pool.loadingPids().count() === 0;
 
         const obj = storeRef.unref(); // synchronous objectForPid — identity map preserves sameness
+
+        if (obj === undefined) {
+            // missingRecord: the pool has no record for this pid — a dangling
+            // ref (store GC or cloud-pool completeness bug upstream; the
+            // record may also arrive later via cloud sync). NEVER write the
+            // failure through the setter: the SvStoreRef stays in the slot,
+            // so the store keeps round-tripping the original pid (diagnostic
+            // breadcrumb, no silent self-heal) and the next access after the
+            // negative-cache window retries. A deserialize/setter THROW is
+            // handled differently by design: it propagates un-recorded and
+            // un-hooked (a loud programming error, not a heal-able miss).
+            const error = new Error("missing record for pid '" + storeRef.pid() + "' in lazy slot '" + this.name() + "' of " + anInstance.svTypeId());
+            const isFirstFailure = storeRef.attemptCount() === 0;
+            storeRef.recordFailedAttempt(error, "missingRecord");
+            if (isFirstFailure) {
+                console.error("Slot.onInstanceMaterializeLazySlot: " + error.message + " — returning null (or the onFailedLazyLoadSlot hook's fallback); will not re-attempt for a growing window");
+            }
+            return this.onInstanceFailedLazyLoad(anInstance, storeRef);
+        }
 
         if (initiatesLoadCycle && !pool.isFinalizing() && pool.loadingPids().count() > 0) {
             pool.didInitLoadingPids();
@@ -1215,6 +1248,51 @@ SvGlobals.globals().ideal.Slot = (class Slot extends Object {
             anInstance.didMaterializeSlot(this);
         }
         return obj;
+    }
+
+    /**
+     * @category StoreRefs for lazy slots
+     * @description The failed-materialization return path: gives the owning
+     * instance a chance to substitute a fallback via an
+     * onFailedLazyLoadSlot<SlotName>(context) hook, then returns
+     * context.result (default null). The context is a mutable object:
+     * { result, error, errorKind, storeRef, slotName } — the hook sets
+     * context.result to override. Called on EVERY failed access, including
+     * negative-cache-latched ones (the latch rate-limits pool lookups and
+     * log spam, not the hook — a fallback must not flicker between values
+     * on alternating accesses), so hooks should be cheap and pure.
+     *
+     * NOTE for hook authors: writing a fallback into the slot through the
+     * setter is STORE-NEUTRAL by construction — the SvStoreRef is still in
+     * the slot, so didUpdateSlot classifies the write as a load and nothing
+     * is marked dirty; the hook also runs inside the materialization counter,
+     * so SvSyncable ancestors skip their cloud-timestamp touch (a fallback
+     * must not schedule a cloud push of an unchanged document). The fallback
+     * is re-derived next boot and the store keeps the dangling pid as a
+     * diagnostic breadcrumb. An owner that genuinely wants a persistent
+     * repair must explicitly call didMutate().
+     * @param {Object} anInstance - The instance owning the slot.
+     * @param {SvStoreRef} storeRef - The ref whose unref failed.
+     * @returns {*} context.result — null unless the hook overrode it.
+     */
+    onInstanceFailedLazyLoad (anInstance, storeRef) {
+        const context = {
+            result: null,
+            error: storeRef.lastError(),
+            errorKind: storeRef.lastErrorKind(),
+            storeRef: storeRef,
+            slotName: this.name()
+        };
+        const hookName = this.methodForFailedLazyLoad();
+        if (anInstance[hookName]) {
+            Slot.beginLazySlotMaterialization();
+            try {
+                anInstance[hookName](context);
+            } finally {
+                Slot.endLazySlotMaterialization();
+            }
+        }
+        return context.result;
     }
 
     /**

--- a/source/library/ideal/proto/Slot.js
+++ b/source/library/ideal/proto/Slot.js
@@ -1101,14 +1101,18 @@ SvGlobals.globals().ideal.Slot = (class Slot extends Object {
      * @category StoreRefs for lazy slots
      * @description True while any lazy slot's stub is being written back into
      * its slot (the setter call in onInstanceMaterializeLazySlot). During that
-     * synchronous window, every didUpdateSlot/didUpdateNode that fires —
-     * anywhere, at any depth of the bubble — was caused by the materialization
-     * (single-threaded JS: nothing else can run). Store-facing reactions
-     * consult this to stay neutral: materialization is NOT a mutation with
-     * respect to the store (the store already holds exactly the value being
-     * loaded), but it IS an event with respect to the UI (views must re-sync)
-     * — so view-facing hooks fire normally while SvObjectPool skips
-     * addDirtyObject and SvSyncable* skip the localLastModified touch.
+     * synchronous window, a didUpdateNode bubble can reach OBJECTS OTHER THAN
+     * the materializing one (ancestors up the parent chain), whose per-instance
+     * isMaterializingLazySlot flag is false — so cross-object echo filtering
+     * needs this globally visible signal (single-threaded JS attributes
+     * anything inside the window to the materialization). Consumers must
+     * filter NARROWLY: only side effects that are pure echoes of loading may
+     * consult this — currently just SvSyncable*.touchLocalModified (the cloud
+     * timestamp; loading is not a local modification). Dirty-marking is NOT
+     * filtered globally — objects genuinely created or changed by hooks during
+     * someone else's materialization must still be stored; the materializing
+     * instance's own write-back echo is filtered per-instance in
+     * SvStorableNode.didMutate instead.
      * A counter, not a boolean, so nested materializations (writing one value
      * can trigger a getter that materializes another) compose correctly.
      * @returns {Boolean}
@@ -1137,14 +1141,16 @@ SvGlobals.globals().ideal.Slot = (class Slot extends Object {
      * @category StoreRefs for lazy slots
      * @description Resolves a lazy slot's SvStoreRef stub into the real stored
      * object and writes it through the setter, so didUpdateSlot hooks and view
-     * sync fire like any other change. Store-facing reactions are suppressed
-     * for the write-back window via the static materialization counter (see
-     * isMaterializingAnyLazySlot): didMutate still FIRES normally — mutation
-     * observers stay honest — but SvObjectPool declines to mark dirty, and
-     * SvSyncable groups decline to touch their cloud timestamp, because
-     * materialization is a no-op with respect to the store. Real load-time
-     * changes (finalInit repairs during unref, didMaterializeSlot hygiene)
-     * run OUTSIDE the bracket and dirty normally.
+     * sync fire like any other change. Materialization is a no-op with respect
+     * to the store but an event with respect to the UI, so exactly two echo
+     * filters apply during the write-back window: the materializing instance's
+     * own didMutate is skipped (per-instance flag, SvStorableNode.didMutate),
+     * and SvSyncable ancestors reached by the didUpdateNode bubble skip their
+     * localLastModified touch (static counter, see
+     * isMaterializingAnyLazySlot). Everything else — including objects
+     * genuinely created or changed by hooks inside the window — dirties and
+     * stores normally, as do real load-time changes (finalInit repairs during
+     * unref, didMaterializeSlot hygiene) which run OUTSIDE the bracket.
      */
     onInstanceMaterializeLazySlot (anInstance) {
         const storeRef = this.onInstanceRawGetValue(anInstance);

--- a/source/library/ideal/proto/Slot.js
+++ b/source/library/ideal/proto/Slot.js
@@ -173,9 +173,13 @@ SvGlobals.globals().ideal.Slot = (class Slot extends Object {
      */
     setIsLazy (aBool) {
         this._isLazy = aBool;
-        if (aBool) {
-            this.setAllowsUndefinedValue(true); // we use undefined to indicate that the value is not yet loaded
-        }
+        // NOTE: an earlier lazy design used undefined as the "not yet loaded"
+        // marker and whitelisted it here via setAllowsUndefinedValue(true).
+        // The SvStoreRef placeholder replaced that design; the whitelist's
+        // only remaining effect was to let a FAILED materialization (e.g.
+        // unref() of a missing record returning undefined) write undefined
+        // into the slot silently. Undefined now fails validation like any
+        // other slot.
         return this;
     }
 

--- a/source/library/node/json/SvSyncableJsonGroup.js
+++ b/source/library/node/json/SvSyncableJsonGroup.js
@@ -145,10 +145,19 @@
 
     /**
      * @description Marks the item as locally modified. Call when content changes.
+     * No-op during lazy-slot materialization: loading a stored value back into
+     * memory is not a local modification — the cloud already has it (or will
+     * compare against the true last edit). Without this guard, the
+     * materialization's didUpdateNode bubble stamps the document "locally
+     * modified", scheduling a spurious cloud push of an unchanged document and
+     * polluting staleness-conflict timestamps.
      * @returns {SvSyncableJsonGroup} This instance
      * @category Sync
      */
     touchLocalModified () {
+        if (Slot.isMaterializingAnyLazySlot()) {
+            return this;
+        }
         this.setLocalLastModified(Date.now());
         return this;
     }

--- a/source/library/node/nodes/base/SvNode.js
+++ b/source/library/node/nodes/base/SvNode.js
@@ -1751,7 +1751,12 @@
      * @returns {SvNode} This instance.
      */
     didUpdateSlotSubnodes (oldValue, newValue) {
-        if (oldValue) {
+        // An SvStoreRef oldValue means a lazy subnodes slot is MATERIALIZING
+        // (see Slot.onInstanceMaterializeLazySlot — the placeholder survives
+        // to the setter precisely so this transition is derivable). The
+        // placeholder was never observed, so there is nothing to remove.
+        const isMaterialization = (oldValue instanceof SvStoreRef);
+        if (oldValue && !isMaterialization) {
             oldValue.removeMutationObserver(this);
         }
 
@@ -1793,6 +1798,19 @@
         }
 
         this._subnodes.forEach(sn => sn.setParentNode(this)); // TODO: isn't this done elsewhere?
+
+        if (isMaterialization) {
+            // Materialization write-back: the assigned list IS the stored
+            // list. The UI half of didChangeSubnodeList still applies (views
+            // must render the loaded subnodes); the store half —
+            // didMutate("subnodes") — must not, because a load is not an
+            // edit. Inlines the UI half; keep in sync with
+            // didChangeSubnodeList.
+            this.scheduleMethod("onDidReorderSubnodes");
+            this.didUpdateNodeIfInitialized();
+            return this;
+        }
+
         this.didChangeSubnodeList(); // not handled automatically
         return this;
     }

--- a/source/library/node/nodes/syncing/SvSyncableArrayNode.js
+++ b/source/library/node/nodes/syncing/SvSyncableArrayNode.js
@@ -115,11 +115,17 @@
     }
 
     /**
-     * @description Marks the collection as locally modified.
+     * @description Marks the collection as locally modified. No-op during
+     * lazy-slot materialization — loading a stored value back into memory is
+     * not a local modification (see SvSyncableJsonGroup.touchLocalModified for
+     * the full rationale).
      * @returns {SvSyncableArrayNode} This instance
      * @category Sync
      */
     touchLocalModified () {
+        if (Slot.isMaterializingAnyLazySlot()) {
+            return this;
+        }
         this.setLocalLastModified(Date.now());
         return this;
     }

--- a/source/library/node/storage/base/SvObjectPool.js
+++ b/source/library/node/storage/base/SvObjectPool.js
@@ -873,6 +873,12 @@
         const puuid = anObject.puuid();
 
         if (this.isStoringObject(anObject)) {
+            // mutated AFTER being stored in the active commit pass. The old
+            // silent return DROPPED the change — in-memory state diverged
+            // from the stored record until the next genuine mutation. Defer
+            // the fresh state to the next commit instead (tripwire-logged;
+            // see deferDirtyObjectDuringStore).
+            this.deferDirtyObjectDuringStore(anObject, new Error().stack);
             return this;
         }
 
@@ -882,13 +888,64 @@
 
         if (!this.dirtyObjects().has(puuid)) {
             this.logDebug(() => "addDirtyObject(" + anObject.svTypeId() + ")");
-            if (this.storingPids() && this.storingPids().has(puuid)) {
-                throw new Error("attempt to double store? did object change after store? is there a loop?");
+            if (this.storingPids() !== null) {
+                // dirtied mid-pass but not yet stored this pass: legal (the
+                // pass stores it in a later loop), but if it turns out the
+                // object was ALREADY in the bucket being walked, the loop
+                // guard will flag it — capture the culprit's stack now so
+                // that report names the code that mutated during the store
+                this.midStoreDirtyStacks().set(puuid, new Error().stack);
             }
             this.dirtyObjects().set(puuid, anObject);
             this.scheduleStore();
         }
 
+        return this;
+    }
+
+    // --- mid-store mutation handling ---
+    // An object mutated during the synchronous store pass, after the pass
+    // already stored it, means its stored record is stale. The old behavior
+    // threw, aborting the WHOLE commit (every save that cycle lost) and
+    // surfacing as "attempt to double store <id>" with no clue WHO mutated.
+    // Now: tripwire-log the mutation-time stack (console.error → error
+    // reports) and re-queue the object for the next commit, which stores the
+    // fresh state. The log is the bug report — mutating during a store pass
+    // is still a defect to fix at the source; this just stops it from being
+    // a data-loss crash.
+
+    midStoreDirtyStacks () {
+        if (!this._midStoreDirtyStacks) {
+            this._midStoreDirtyStacks = new Map();
+        }
+        return this._midStoreDirtyStacks;
+    }
+
+    deferDirtyObjectDuringStore (anObject, dirtySourceStack) {
+        const puuid = anObject.puuid();
+        const stack = dirtySourceStack || this.midStoreDirtyStacks().get(puuid) || "(mutation-time stack not captured)";
+
+        // A serializer that mutates ITS OWN stored slots re-defers every
+        // commit forever (defer → next commit → same mutation → defer …).
+        // Cap consecutive defers per pid: give up loudly, keep the stale
+        // record (the pre-defer behavior), and break the commit loop. The
+        // counter resets when the object gets through a pass without
+        // re-deferring (see storeDirtyObjects).
+        if (!this._consecutiveDeferCounts) {
+            this._consecutiveDeferCounts = new Map();
+        }
+        const count = (this._consecutiveDeferCounts.get(puuid) || 0) + 1;
+        this._consecutiveDeferCounts.set(puuid, count);
+        if (count > 3) {
+            console.error(this.logPrefix() + "TRIPWIRE: " + anObject.svTypeId() + " re-mutated during " + count + " consecutive store passes — giving up on it (stored record stays stale) to break the commit loop. Something mutates this object every time it is serialized; fix that. Mutation-time stack:\n" + stack);
+            return this;
+        }
+
+        console.error(this.logPrefix() + "TRIPWIRE: " + anObject.svTypeId() + " was mutated during the store pass, after it was already stored this pass — deferring the fresh state to the next commit. Mutation-time stack:\n" + stack);
+        if (!this._deferredDirtyObjects) {
+            this._deferredDirtyObjects = new Map();
+        }
+        this._deferredDirtyObjects.set(puuid, anObject);
         return this;
     }
 
@@ -911,10 +968,13 @@
         if (this.storingPids() !== null) {
             // we might be in the middle of storing changes
             if (this.storingPids().has(anObject.puuid())) {
-                // looks like this object is already queued to be stored
-                this.logDebug(() => "forceAddDirtyObject(" + anObject.svTypeId() + ") already queued to be stored - skipping");
+                // already STORED this pass (storingPids holds stored pids,
+                // not queued ones) — the old silent skip dropped the change,
+                // leaving a stale record; defer to the next commit instead
+                this.deferDirtyObjectDuringStore(anObject, new Error().stack);
                 return this;
             }
+            this.midStoreDirtyStacks().set(anObject.puuid(), new Error().stack);
         }
         if (!this._forcedDirtyObjectsSet) {
             this._forcedDirtyObjectsSet = new Set();
@@ -1000,9 +1060,12 @@
                 //console.log("  storing pid " + puuid);
 
                 if (this.storingPids().has(puuid)) {
-                    const msg = "ERROR: attempt to double store " + obj.svTypeId();
-                    console.log(msg);
-                    throw new Error(msg);
+                    // already stored this pass, then mutated mid-pass (the
+                    // dirty happened before its store turn, so addDirtyObject
+                    // couldn't flag it) — defer the fresh state to the next
+                    // commit with the mutation-time stack captured at add time
+                    this.deferDirtyObjectDuringStore(obj, null);
+                    return;
                 }
 
                 this.storingPids().add(puuid);
@@ -1025,6 +1088,28 @@
         }
 
         this.setStoringPids(null);
+        this._midStoreDirtyStacks = null;
+
+        // pids that got through this pass WITHOUT re-deferring have settled —
+        // reset their consecutive-defer counters
+        if (this._consecutiveDeferCounts) {
+            this._consecutiveDeferCounts.keysArray().forEach((pid) => {
+                if (!this._deferredDirtyObjects || !this._deferredDirtyObjects.has(pid)) {
+                    this._consecutiveDeferCounts.delete(pid);
+                }
+            });
+        }
+
+        // objects mutated after their store this pass re-queue for the next
+        // commit, so their fresh state persists (their stored record is stale)
+        if (this._deferredDirtyObjects) {
+            this._deferredDirtyObjects.forEachKV((pid, obj) => {
+                this.dirtyObjects().set(pid, obj);
+            });
+            this._deferredDirtyObjects = null;
+            this.scheduleStore();
+        }
+
         return totalStoreCount;
     }
 

--- a/source/library/node/storage/base/SvObjectPool.js
+++ b/source/library/node/storage/base/SvObjectPool.js
@@ -805,9 +805,10 @@
     /**
      * @description handle the object did mutate event
      * @param {Object} anObject - the object that was mutated
+     * @param {String} slotName - the name of the slot that was mutated
      * @returns {void}
      */
-    onDidMutateObject (anObject) {
+    onDidMutateObject (anObject /* , slotName */) {
         // NOTE: no lazy-materialization filtering here. A blanket time-window
         // skip would also drop mutations of objects GENUINELY created or
         // changed by hooks during someone else's materialization — those must

--- a/source/library/node/storage/base/SvObjectPool.js
+++ b/source/library/node/storage/base/SvObjectPool.js
@@ -808,17 +808,13 @@
      * @returns {void}
      */
     onDidMutateObject (anObject) {
-        // Store policy: a mutation arriving during lazy-slot materialization
-        // is not a store-relevant change — the store already holds exactly
-        // the value being written back into the slot, and any didMutate inside
-        // that synchronous window (on the materializing object OR an ancestor
-        // reached by the didUpdateNode bubble) was caused by it. The didMutate
-        // broadcast still fires (it's an honest "memory changed" signal; other
-        // observers may care) — the store just declines to mark dirty.
-        // See Slot.isMaterializingAnyLazySlot.
-        if (Slot.isMaterializingAnyLazySlot()) {
-            return;
-        }
+        // NOTE: no lazy-materialization filtering here. A blanket time-window
+        // skip would also drop mutations of objects GENUINELY created or
+        // changed by hooks during someone else's materialization — those must
+        // be stored. The materialization write-back echo is filtered at its
+        // precise source instead: the materializing instance's own didMutate
+        // (SvStorableNode.didMutate, per-instance flag) and the cross-object
+        // timestamp touch (SvSyncable*.touchLocalModified, global flag).
         //if (anObject.hasDoneInit() && ) {
         if (this.hasActiveObject(anObject) && !this.isLoadingObject(anObject) && anObject.shouldStore()) {
             this.addDirtyObject(anObject);

--- a/source/library/node/storage/base/SvObjectPool.js
+++ b/source/library/node/storage/base/SvObjectPool.js
@@ -808,6 +808,17 @@
      * @returns {void}
      */
     onDidMutateObject (anObject) {
+        // Store policy: a mutation arriving during lazy-slot materialization
+        // is not a store-relevant change — the store already holds exactly
+        // the value being written back into the slot, and any didMutate inside
+        // that synchronous window (on the materializing object OR an ancestor
+        // reached by the didUpdateNode bubble) was caused by it. The didMutate
+        // broadcast still fires (it's an honest "memory changed" signal; other
+        // observers may care) — the store just declines to mark dirty.
+        // See Slot.isMaterializingAnyLazySlot.
+        if (Slot.isMaterializingAnyLazySlot()) {
+            return;
+        }
         //if (anObject.hasDoneInit() && ) {
         if (this.hasActiveObject(anObject) && !this.isLoadingObject(anObject) && anObject.shouldStore()) {
             this.addDirtyObject(anObject);

--- a/source/library/node/storage/base/SvStoreRef.js
+++ b/source/library/node/storage/base/SvStoreRef.js
@@ -77,4 +77,84 @@
         return this.store().refForPid(this.pid());
     }
 
+    // --- failure bookkeeping (negative cache for lazy-slot materialization) ---
+    //
+    // A ref whose unref() failed (missing record) stays in the slot, so the
+    // getter naturally retries on next access. UI sync hammers getters every
+    // render pass, so without a latch one missing record means a pool lookup
+    // and log line per tick. These fields rate-limit re-ATTEMPTS only — the
+    // owner's onFailedLazyLoadSlot<Name> hook still runs on every failed
+    // access (see Slot.onInstanceFailedLazyLoad). Today's failures are
+    // deterministic (a record absent from the local pool stays absent), so
+    // this is negative caching, not transient-error backoff; on success the
+    // ref is replaced by the real value and this state dies with it.
+    // Fields are defined lazily on first failure so the happy path pays
+    // nothing.
+
+    /**
+     * @description Number of failed materialization attempts recorded on this ref.
+     * @returns {Number}
+     * @category Failure Handling
+     */
+    attemptCount () {
+        return this._attemptCount || 0;
+    }
+
+    /**
+     * @description The Error from the most recent failed attempt, or null.
+     * @returns {Error|null}
+     * @category Failure Handling
+     */
+    lastError () {
+        return this._lastError || null;
+    }
+
+    /**
+     * @description The kind of the most recent failure ("missingRecord" for now;
+     * transient kinds arrive with async pools), or null.
+     * @returns {String|null}
+     * @category Failure Handling
+     */
+    lastErrorKind () {
+        return this._lastErrorKind || null;
+    }
+
+    /**
+     * @description Records a failed materialization attempt.
+     * @param {Error} error - The failure.
+     * @param {String} errorKind - Classification, e.g. "missingRecord".
+     * @returns {SvStoreRef}
+     * @category Failure Handling
+     */
+    recordFailedAttempt (error, errorKind) {
+        if (!this._lastAttemptTime) {
+            Object.defineSlot(this, "_attemptCount", 0);
+            Object.defineSlot(this, "_lastAttemptTime", null);
+            Object.defineSlot(this, "_lastError", null);
+            Object.defineSlot(this, "_lastErrorKind", null);
+        }
+        this._attemptCount = this.attemptCount() + 1;
+        this._lastAttemptTime = Date.now();
+        this._lastError = error;
+        this._lastErrorKind = errorKind;
+        return this;
+    }
+
+    /**
+     * @description Whether a materialization attempt (a pool lookup) is allowed
+     * now: true if never attempted, or if the growing window since the last
+     * failed attempt has elapsed (5s doubling per attempt, capped at 60s —
+     * bounded, since deterministic failures shouldn't churn). There is no
+     * terminal give-up state: the next access after the window may always retry.
+     * @returns {Boolean}
+     * @category Failure Handling
+     */
+    canAttemptNow () {
+        if (!this._lastAttemptTime) {
+            return true;
+        }
+        const windowMs = Math.min(5000 * Math.pow(2, this.attemptCount() - 1), 60000);
+        return (Date.now() - this._lastAttemptTime) >= windowMs;
+    }
+
 }.initThisClass());

--- a/source/library/node/storage/base/SvStoreRef.js
+++ b/source/library/node/storage/base/SvStoreRef.js
@@ -4,8 +4,6 @@
 /** * @class SvStoreRef
  * @extends Object
  * @classdesc SvStoreRef class for handling store references and persistent IDs.
- 
- 
  */
 
 (class SvStoreRef extends Object {

--- a/source/library/node/storage/nodes/SvStorableNode.js
+++ b/source/library/node/storage/nodes/SvStorableNode.js
@@ -108,11 +108,13 @@
 	        return this;
 	    }
 
-        if (aSlot.shouldStoreSlot() && !this.isMaterializingLazySlot()) {
-            // materializing a lazy slot's stored value is not a semantic change:
-            // update hooks (above) fire so views sync, but the object must not
-            // be marked dirty and mutation observers must not be notified
-            //this.didMutate(aSlot.name())
+        if (aSlot.shouldStoreSlot()) {
+            // NOTE: didMutate fires even during lazy-slot materialization —
+            // it is an honest "in-memory state changed" broadcast and other
+            // observers may care. The STORE's policy that materialization is
+            // not a store-relevant change lives with the store:
+            // SvObjectPool.onDidMutateObject consults
+            // Slot.isMaterializingAnyLazySlot() and declines to mark dirty.
             this.didMutate();
         }
 

--- a/source/library/node/storage/nodes/SvStorableNode.js
+++ b/source/library/node/storage/nodes/SvStorableNode.js
@@ -95,6 +95,29 @@
     }
 
     /**
+     * @description Mutation broadcast, filtered for the lazy-slot
+     * materialization write-back echo. While THIS instance's stub is being
+     * written back into its slot, its own state is exactly the stored state —
+     * broadcasting a mutation would mark it dirty for a change the store
+     * already has (and, mid-store-pass, trip the pool's double-store guard).
+     * Per-INSTANCE deliberately: objects genuinely created or changed by
+     * hooks during someone else's materialization must still broadcast and be
+     * stored — only the materializing object's own echo is filtered. The
+     * cross-object side effect (the didUpdateNode bubble touching an
+     * ancestor's cloud timestamp) is handled separately by
+     * SvSyncable*.touchLocalModified consulting the global
+     * Slot.isMaterializingAnyLazySlot().
+     * @param {string} [optionalSlotName]
+     * @category Mutation
+     */
+    didMutate (optionalSlotName) {
+        if (this.isMaterializingLazySlot()) {
+            return;
+        }
+        super.didMutate(optionalSlotName);
+    }
+
+    /**
      * @description Handles updates to slots.
      * @param {Object} aSlot - The slot being updated.
      * @param {*} oldValue - The old value of the slot.
@@ -109,12 +132,9 @@
 	    }
 
         if (aSlot.shouldStoreSlot()) {
-            // NOTE: didMutate fires even during lazy-slot materialization —
-            // it is an honest "in-memory state changed" broadcast and other
-            // observers may care. The STORE's policy that materialization is
-            // not a store-relevant change lives with the store:
-            // SvObjectPool.onDidMutateObject consults
-            // Slot.isMaterializingAnyLazySlot() and declines to mark dirty.
+            // the materialization write-back echo is filtered per-instance in
+            // this class's didMutate override, so all self-didMutate paths
+            // (this one, didChangeSubnodeList, …) share one guard
             this.didMutate();
         }
 

--- a/source/library/node/storage/nodes/SvStorableNode.js
+++ b/source/library/node/storage/nodes/SvStorableNode.js
@@ -95,29 +95,6 @@
     }
 
     /**
-     * @description Mutation broadcast, filtered for the lazy-slot
-     * materialization write-back echo. While THIS instance's stub is being
-     * written back into its slot, its own state is exactly the stored state —
-     * broadcasting a mutation would mark it dirty for a change the store
-     * already has (and, mid-store-pass, trip the pool's double-store guard).
-     * Per-INSTANCE deliberately: objects genuinely created or changed by
-     * hooks during someone else's materialization must still broadcast and be
-     * stored — only the materializing object's own echo is filtered. The
-     * cross-object side effect (the didUpdateNode bubble touching an
-     * ancestor's cloud timestamp) is handled separately by
-     * SvSyncable*.touchLocalModified consulting the global
-     * Slot.isMaterializingAnyLazySlot().
-     * @param {string} [optionalSlotName]
-     * @category Mutation
-     */
-    didMutate (optionalSlotName) {
-        if (this.isMaterializingLazySlot()) {
-            return;
-        }
-        super.didMutate(optionalSlotName);
-    }
-
-    /**
      * @description Handles updates to slots.
      * @param {Object} aSlot - The slot being updated.
      * @param {*} oldValue - The old value of the slot.
@@ -131,10 +108,16 @@
 	        return this;
 	    }
 
-        if (aSlot.shouldStoreSlot()) {
-            // the materialization write-back echo is filtered per-instance in
-            // this class's didMutate override, so all self-didMutate paths
-            // (this one, didChangeSubnodeList, …) share one guard
+        if (aSlot.shouldStoreSlot() && !(oldValue instanceof SvStoreRef)) {
+            // An SvStoreRef → value transition is a lazy slot MATERIALIZING —
+            // a load, not an edit: the store already holds exactly the value
+            // being written back, so marking dirty would re-store known state
+            // (and, mid-store-pass, trip the pool's double-store guard). The
+            // classification is DERIVED from the transition itself (the
+            // SvStoreRef survives to the setter — see
+            // Slot.onInstanceMaterializeLazySlot), so genuinely new or changed
+            // objects during someone else's materialization still didMutate
+            // normally. Every other transition is a real edit and dirties.
             this.didMutate();
         }
 

--- a/tests/headless/TestLazyMaterializationNeutrality.js
+++ b/tests/headless/TestLazyMaterializationNeutrality.js
@@ -15,24 +15,24 @@
  *   - Materializing IS an event with respect to the UI — memory's shape
  *     changed, views must re-sync — so didUpdateNode still fires and bubbles.
  *
- * Mechanism under test — two narrowly-scoped echo filters:
- *   - PER-INSTANCE: the materializing object's own didMutate is skipped
- *     (SvStorableNode.didMutate + isMaterializingLazySlot) — its state IS the
- *     stored state being written back. Deliberately per-instance so objects
+ * Mechanism under test — DERIVED classification plus one narrow counter:
+ *   - The SvStoreRef placeholder SURVIVES to the setter write
+ *     (Slot.onInstanceMaterializeLazySlot no longer pre-clears it), so
+ *     didUpdateSlot receives it as oldValue. The SvStoreRef → value
+ *     transition is unforgeable evidence that the write is a LOAD:
+ *     SvStorableNode.didUpdateSlot skips didMutate on it, and
+ *     SvNode.didUpdateSlotSubnodes skips removeMutationObserver and the
+ *     store half of didChangeSubnodeList. No per-instance flags. Objects
  *     genuinely CREATED or changed by hooks during someone else's
- *     materialization still broadcast and get stored (a blanket time-window
- *     filter at the pool would drop them — never-stored objects have no other
- *     path into the store).
- *   - GLOBAL: Slot.isMaterializingAnyLazySlot(), a STATIC counter bracketing
- *     the setter write-back — needed because the didUpdateNode bubble reaches
- *     ANCESTORS whose per-instance flag is false. Consulted ONLY by
- *     SvSyncableJsonGroup/SvSyncableArrayNode.touchLocalModified() (loading is
- *     not a local modification; the cloud timestamp must not move). A counter
- *     because materializations can nest; single-threaded JS makes the
- *     attribution sound.
- *   - A throwing setter restores the SvStoreRef stub (catch + rethrow), so a
- *     failed materialization is retryable instead of leaving the slot
- *     permanently null.
+ *     materialization emit ordinary transitions and are stored normally.
+ *   - GLOBAL counter Slot.isMaterializingAnyLazySlot() remains for exactly
+ *     one consumer: SvSyncableJsonGroup/SvSyncableArrayNode
+ *     .touchLocalModified() — the didUpdateNode bubble carries no oldValue,
+ *     so the cross-object cloud-timestamp echo can't be derived and needs
+ *     time-window attribution (sound in single-threaded JS; a counter
+ *     because materializations can nest).
+ *   - A throwing setter needs no restore logic: the SvStoreRef was never
+ *     cleared, so it is still in the slot and the next access retries.
  *
  * Usage (from the strvct root):
  *   node source/boot/index-builder/ImportsIndexer.js   # if index is stale
@@ -74,6 +74,7 @@ async function boot () {
 // --- helpers -------------------------------------------------------------
 
 let TestLazyDocument = null;
+let lastSectionHookOldValue; // captured by the test class's slot hook
 
 // A syncable document (stand-in for UoCharacter) with one LAZY stored slot,
 // mirroring how character sheet sections are declared.
@@ -93,13 +94,14 @@ function defineTestClass () {
         }
 
         // Stand-in for the production hook chain: assigning a section slot
-        // triggers hooks (didChangeSubnodeList, subnode wiring, …) that bubble
-        // a didUpdateNode on the enclosing document — which is exactly the
-        // path that reaches SvSyncableJsonGroup.didUpdateNode →
-        // touchLocalModified and (pre-fix) dirtied the document from a
-        // materialization. The slot hook fires INSIDE the materialization
-        // write-back window, like the real chain.
-        didUpdateSlotSection (/*oldValue, newValue*/) {
+        // triggers hooks that bubble a didUpdateNode on the enclosing
+        // document — the path that reaches SvSyncableJsonGroup.didUpdateNode
+        // → touchLocalModified and (pre-fix) dirtied the document from a
+        // materialization. Also captures its oldValue so the test can assert
+        // the derived-evidence contract: during materialization the hook
+        // receives the SvStoreRef placeholder.
+        didUpdateSlotSection (oldValue /*, newValue*/) {
+            lastSectionHookOldValue = oldValue;
             this.didUpdateNode();
         }
     }).initThisClass();
@@ -110,8 +112,8 @@ function newPool () {
 }
 
 // Store the doc + section, then swap the section slot back to an SvStoreRef
-// stub — the state a reloaded, not-yet-touched lazy slot is in.
-function stubSectionSlot (pool, doc) {
+// placeholder — the state a reloaded, not-yet-touched lazy slot is in.
+function placeStoreRefInSectionSlot (pool, doc) {
     const SvStoreRef = SvGlobals.get("SvStoreRef");
     const section = doc.section(); // materialized instance (fresh doc)
     const ref = SvStoreRef.clone();
@@ -121,28 +123,33 @@ function stubSectionSlot (pool, doc) {
     return ref;
 }
 
+async function storeDocAndSection (pool, doc) {
+    pool.addActiveObject(doc);
+    pool.addActiveObject(doc.section());
+    pool.dirtyObjects().set(doc.puuid(), doc);
+    pool.dirtyObjects().set(doc.section().puuid(), doc.section());
+    await pool.commitStoreDirtyObjects();
+}
+
 // --- tests ---------------------------------------------------------------
 
 async function testMaterializationIsStoreNeutralButUiVisible () {
     console.log("\nMaterialization: store-neutral (no dirty, no timestamp) but UI-visible (didUpdateNode bubbles)");
 
     const Slot = SvGlobals.get("Slot");
+    const SvStoreRef = SvGlobals.get("SvStoreRef");
     const pool = newPool();
     const doc = TestLazyDocument.clone();
 
-    // Persist doc + section so the store genuinely holds the section's record.
-    pool.addActiveObject(doc);
-    pool.addActiveObject(doc.section());
-    pool.dirtyObjects().set(doc.puuid(), doc);
-    pool.dirtyObjects().set(doc.section().puuid(), doc.section());
-    await pool.commitStoreDirtyObjects();
+    await storeDocAndSection(pool, doc);
     check(pool.dirtyObjects().size === 0, "setup: both objects stored, dirty set drained");
 
-    // Swap the slot to a stub (simulated reload state) and set baselines.
-    stubSectionSlot(pool, doc);
+    // Swap the slot to an SvStoreRef (simulated reload state) and set baselines.
+    placeStoreRefInSectionSlot(pool, doc);
     doc.setLocalLastModified(12345);
     pool.dirtyObjects().clear(); // discard baseline-setting dirt; we assert deltas from here
     const timestampBaseline = doc.localLastModified();
+    lastSectionHookOldValue = undefined;
 
     // Spy: the UI-facing channel — didUpdateNode on the DOCUMENT (the bubble's
     // destination) must still fire during materialization.
@@ -157,7 +164,8 @@ async function testMaterializationIsStoreNeutralButUiVisible () {
     const materialized = doc.section();
 
     check(materialized === pool.objectForPid(materialized.puuid()), "getter returned the identity-mapped section instance");
-    check(!(doc.thisPrototype().slotNamed("section").onInstanceRawGetValue(doc) instanceof SvGlobals.get("SvStoreRef")), "stub replaced by the real value");
+    check(!(doc.thisPrototype().slotNamed("section").onInstanceRawGetValue(doc) instanceof SvStoreRef), "SvStoreRef replaced by the real value");
+    check(lastSectionHookOldValue instanceof SvStoreRef, "DERIVED evidence: the slot hook received the SvStoreRef as oldValue");
     check(pool.dirtyObjects().size === 0, "STORE-neutral: no object was marked dirty by materialization");
     check(doc.localLastModified() === timestampBaseline, "STORE-neutral: localLastModified unchanged (no spurious cloud touch)");
     check(docDidUpdateNodeCount > 0, "UI-visible: didUpdateNode bubbled to the document during materialization");
@@ -176,19 +184,14 @@ async function testNewObjectCreatedDuringMaterializationStillStores () {
     const pool = newPool();
     const doc = TestLazyDocument.clone();
 
-    pool.addActiveObject(doc);
-    pool.addActiveObject(doc.section());
-    pool.dirtyObjects().set(doc.puuid(), doc);
-    pool.dirtyObjects().set(doc.section().puuid(), doc.section());
-    await pool.commitStoreDirtyObjects();
-
-    stubSectionSlot(pool, doc);
+    await storeDocAndSection(pool, doc);
+    placeStoreRefInSectionSlot(pool, doc);
     pool.dirtyObjects().clear();
 
-    // Hook side effect INSIDE the write-back window: create a brand-new
-    // stored object (a blanket time-window dirty filter would drop it — the
-    // store has never seen it, so its didMutate is its only path to being
-    // persisted).
+    // Hook side effect INSIDE the write-back: create a brand-new stored
+    // object. Its own transitions are ordinary (no SvStoreRef oldValue), so
+    // it must be dirtied and stored — the never-stored object's didMutate is
+    // its only path into the store.
     let created = null;
     const realHook = doc.didUpdateSlotSection.bind(doc);
     doc.didUpdateSlotSection = function (oldValue, newValue) {
@@ -204,27 +207,22 @@ async function testNewObjectCreatedDuringMaterializationStillStores () {
 
     check(created !== null, "hook ran during materialization and created a new object");
     check(pool.dirtyObjects().has(created.puuid()), "the NEW object was marked dirty despite the materialization window");
-    check(!pool.dirtyObjects().has(doc.puuid()), "…while the materializing doc's own write-back echo was still filtered");
+    check(!pool.dirtyObjects().has(doc.puuid()), "…while the materializing doc's own write-back echo was still filtered (derived)");
 
     await pool.commitStoreDirtyObjects();
     check(pool.kvMap().hasKey(created.puuid()), "the new object was stored by the next commit");
 }
 
-async function testThrowingSetterRestoresStub () {
-    console.log("\nA throwing setter restores the stub (failure is retryable, exception propagates)");
+async function testThrowingSetterLeavesStoreRefInPlace () {
+    console.log("\nA throwing setter leaves the SvStoreRef in place (failure is retryable, exception propagates)");
 
     const Slot = SvGlobals.get("Slot");
     const SvStoreRef = SvGlobals.get("SvStoreRef");
     const pool = newPool();
     const doc = TestLazyDocument.clone();
 
-    pool.addActiveObject(doc);
-    pool.addActiveObject(doc.section());
-    pool.dirtyObjects().set(doc.puuid(), doc);
-    pool.dirtyObjects().set(doc.section().puuid(), doc.section());
-    await pool.commitStoreDirtyObjects();
-
-    stubSectionSlot(pool, doc);
+    await storeDocAndSection(pool, doc);
+    placeStoreRefInSectionSlot(pool, doc);
 
     // Sabotage the setter for one call.
     const realSetSection = doc.setSection.bind(doc);
@@ -239,7 +237,7 @@ async function testThrowingSetterRestoresStub () {
         threw = e;
     }
     check(threw !== null && /simulated setter failure/.test(threw.message), "exception propagated (not hidden)");
-    check(doc.thisPrototype().slotNamed("section").onInstanceRawGetValue(doc) instanceof SvStoreRef, "stub RESTORED after the throw (slot not left null)");
+    check(doc.thisPrototype().slotNamed("section").onInstanceRawGetValue(doc) instanceof SvStoreRef, "SvStoreRef still in the slot after the throw (never cleared — no restore logic needed)");
     check(Slot.isMaterializingAnyLazySlot() === false, "materialization counter reset by the finally");
 
     // Heal the setter; the next access retries and succeeds.
@@ -260,7 +258,7 @@ async function main () {
 
     await testMaterializationIsStoreNeutralButUiVisible();
     await testNewObjectCreatedDuringMaterializationStillStores();
-    await testThrowingSetterRestoresStub();
+    await testThrowingSetterLeavesStoreRefInPlace();
 
     console.log("\n" + passed + " passed, " + failed + " failed");
     process.exit(failed === 0 ? 0 : 1);

--- a/tests/headless/TestLazyMaterializationNeutrality.js
+++ b/tests/headless/TestLazyMaterializationNeutrality.js
@@ -1,0 +1,231 @@
+#!/usr/bin/env node
+
+"use strict";
+
+/**
+ * Headless test: lazy-slot materialization is store-neutral but UI-visible.
+ *
+ * The invariant (two-sided):
+ *   - Materializing a lazy slot is NOT a mutation with respect to the STORE —
+ *     the store already contains exactly the value being loaded. So it must
+ *     not mark any object dirty (not the materializing object, and not an
+ *     ancestor reached by the didUpdateNode bubble), and it must not touch a
+ *     syncable document's localLastModified cloud timestamp (which would
+ *     schedule a spurious cloud push of an unchanged document).
+ *   - Materializing IS an event with respect to the UI — memory's shape
+ *     changed, views must re-sync — so didUpdateNode still fires and bubbles.
+ *
+ * Mechanism under test:
+ *   - Slot.isMaterializingAnyLazySlot(): a STATIC counter bracketing the
+ *     setter write-back in onInstanceMaterializeLazySlot. Static because the
+ *     side effects cross object boundaries (the bubble dirties ANCESTORS,
+ *     whose per-instance isMaterializingLazySlot flag is false); a counter
+ *     because materializations can nest. Single-threaded JS makes the
+ *     attribution sound: anything that fires inside the synchronous window
+ *     was caused by the materialization.
+ *   - didMutate still FIRES normally (it is an honest "memory changed"
+ *     broadcast); the STORE's policy lives at the receiver:
+ *     SvObjectPool.onDidMutateObject declines addDirtyObject during
+ *     materialization.
+ *   - SvSyncableJsonGroup/SvSyncableArrayNode.touchLocalModified() are no-ops
+ *     during materialization (the timestamp write is direct store-facing
+ *     state; no receiver can intercept it).
+ *   - A throwing setter restores the SvStoreRef stub (catch + rethrow), so a
+ *     failed materialization is retryable instead of leaving the slot
+ *     permanently null.
+ *
+ * Usage (from the strvct root):
+ *   node source/boot/index-builder/ImportsIndexer.js   # if index is stale
+ *   node tests/headless/TestLazyMaterializationNeutrality.js
+ */
+
+const path = require("path");
+const { pathToFileURL } = require("url");
+
+// Boot expects cwd to be the site root (build/_index.json lives there).
+const strvctRoot = path.join(__dirname, "..", "..");
+process.chdir(strvctRoot);
+
+let passed = 0;
+let failed = 0;
+
+function check (condition, message) {
+    if (condition) {
+        passed++;
+        console.log("  \x1b[32m✓\x1b[0m " + message);
+    } else {
+        failed++;
+        console.log("  \x1b[31m✗\x1b[0m " + message);
+    }
+}
+
+async function boot () {
+    const bootFile = (p) => import(pathToFileURL(path.join(strvctRoot, p)).href);
+    await bootFile("source/boot/SvGlobals.js");
+    await bootFile("source/boot/SvPlatform.js");
+    await bootFile("source/boot/StrvctFile.js");
+    await bootFile("source/boot/SvBootLoader.js");
+
+    const SvBootLoader = SvGlobals.get("SvBootLoader");
+    SvBootLoader._bootPath = "source/boot";
+    await SvBootLoader.asyncRun();
+}
+
+// --- helpers -------------------------------------------------------------
+
+let TestLazyDocument = null;
+
+// A syncable document (stand-in for UoCharacter) with one LAZY stored slot,
+// mirroring how character sheet sections are declared.
+function defineTestClass () {
+    const SvSyncableJsonGroup = SvGlobals.get("SvSyncableJsonGroup");
+    const SvJsonGroup = SvGlobals.get("SvJsonGroup");
+    TestLazyDocument = (class TestLazyDocument extends SvSyncableJsonGroup {
+        initPrototypeSlots () {
+            {
+                const slot = this.newSlot("section", null);
+                slot.setSlotType("SvJsonGroup");
+                slot.setShouldStoreSlot(true);
+                slot.setAllowsNullValue(true);
+                slot.setFinalInitProto(SvJsonGroup);
+                slot.setIsLazy(true);
+            }
+        }
+
+        // Stand-in for the production hook chain: assigning a section slot
+        // triggers hooks (didChangeSubnodeList, subnode wiring, …) that bubble
+        // a didUpdateNode on the enclosing document — which is exactly the
+        // path that reaches SvSyncableJsonGroup.didUpdateNode →
+        // touchLocalModified and (pre-fix) dirtied the document from a
+        // materialization. The slot hook fires INSIDE the materialization
+        // write-back window, like the real chain.
+        didUpdateSlotSection (/*oldValue, newValue*/) {
+            this.didUpdateNode();
+        }
+    }).initThisClass();
+}
+
+function newPool () {
+    return SvGlobals.get("SvObjectPool").clone();
+}
+
+// Store the doc + section, then swap the section slot back to an SvStoreRef
+// stub — the state a reloaded, not-yet-touched lazy slot is in.
+function stubSectionSlot (pool, doc) {
+    const SvStoreRef = SvGlobals.get("SvStoreRef");
+    const section = doc.section(); // materialized instance (fresh doc)
+    const ref = SvStoreRef.clone();
+    ref.setPid(section.puuid());
+    ref.setStore(pool);
+    doc.thisPrototype().slotNamed("section").onInstanceRawSetValue(doc, ref);
+    return ref;
+}
+
+// --- tests ---------------------------------------------------------------
+
+async function testMaterializationIsStoreNeutralButUiVisible () {
+    console.log("\nMaterialization: store-neutral (no dirty, no timestamp) but UI-visible (didUpdateNode bubbles)");
+
+    const Slot = SvGlobals.get("Slot");
+    const pool = newPool();
+    const doc = TestLazyDocument.clone();
+
+    // Persist doc + section so the store genuinely holds the section's record.
+    pool.addActiveObject(doc);
+    pool.addActiveObject(doc.section());
+    pool.dirtyObjects().set(doc.puuid(), doc);
+    pool.dirtyObjects().set(doc.section().puuid(), doc.section());
+    await pool.commitStoreDirtyObjects();
+    check(pool.dirtyObjects().size === 0, "setup: both objects stored, dirty set drained");
+
+    // Swap the slot to a stub (simulated reload state) and set baselines.
+    stubSectionSlot(pool, doc);
+    doc.setLocalLastModified(12345);
+    pool.dirtyObjects().clear(); // discard baseline-setting dirt; we assert deltas from here
+    const timestampBaseline = doc.localLastModified();
+
+    // Spy: the UI-facing channel — didUpdateNode on the DOCUMENT (the bubble's
+    // destination) must still fire during materialization.
+    let docDidUpdateNodeCount = 0;
+    const realDidUpdateNode = doc.didUpdateNode.bind(doc);
+    doc.didUpdateNode = function () {
+        docDidUpdateNodeCount++;
+        return realDidUpdateNode();
+    };
+
+    // Materialize via the public getter — the real trigger path.
+    const materialized = doc.section();
+
+    check(materialized === pool.objectForPid(materialized.puuid()), "getter returned the identity-mapped section instance");
+    check(!(doc.thisPrototype().slotNamed("section").onInstanceRawGetValue(doc) instanceof SvGlobals.get("SvStoreRef")), "stub replaced by the real value");
+    check(pool.dirtyObjects().size === 0, "STORE-neutral: no object was marked dirty by materialization");
+    check(doc.localLastModified() === timestampBaseline, "STORE-neutral: localLastModified unchanged (no spurious cloud touch)");
+    check(docDidUpdateNodeCount > 0, "UI-visible: didUpdateNode bubbled to the document during materialization");
+    check(Slot.isMaterializingAnyLazySlot() === false, "materialization counter back to zero");
+
+    // A REAL change afterwards still dirties + touches normally.
+    doc.setCloudLastModified(999);
+    check(pool.dirtyObjects().size > 0, "control: a genuine slot change after materialization still marks dirty");
+    doc.didUpdateNode();
+    check(doc.localLastModified() > timestampBaseline, "control: a genuine didUpdateNode still touches localLastModified");
+}
+
+async function testThrowingSetterRestoresStub () {
+    console.log("\nA throwing setter restores the stub (failure is retryable, exception propagates)");
+
+    const Slot = SvGlobals.get("Slot");
+    const SvStoreRef = SvGlobals.get("SvStoreRef");
+    const pool = newPool();
+    const doc = TestLazyDocument.clone();
+
+    pool.addActiveObject(doc);
+    pool.addActiveObject(doc.section());
+    pool.dirtyObjects().set(doc.puuid(), doc);
+    pool.dirtyObjects().set(doc.section().puuid(), doc.section());
+    await pool.commitStoreDirtyObjects();
+
+    stubSectionSlot(pool, doc);
+
+    // Sabotage the setter for one call.
+    const realSetSection = doc.setSection.bind(doc);
+    doc.setSection = function () {
+        throw new Error("simulated setter failure");
+    };
+
+    let threw = null;
+    try {
+        doc.section();
+    } catch (e) {
+        threw = e;
+    }
+    check(threw !== null && /simulated setter failure/.test(threw.message), "exception propagated (not hidden)");
+    check(doc.thisPrototype().slotNamed("section").onInstanceRawGetValue(doc) instanceof SvStoreRef, "stub RESTORED after the throw (slot not left null)");
+    check(Slot.isMaterializingAnyLazySlot() === false, "materialization counter reset by the finally");
+
+    // Heal the setter; the next access retries and succeeds.
+    doc.setSection = realSetSection;
+    const materialized = doc.section();
+    check(materialized !== null && !(materialized instanceof SvStoreRef), "retry after repair materializes successfully");
+}
+
+async function main () {
+    console.log("TestLazyMaterializationNeutrality: booting strvct…");
+    await boot();
+
+    // Isolate from the scheduler's fire-and-forget auto-commits; we drive
+    // commitStoreDirtyObjects() explicitly.
+    SvGlobals.get("SvSyncScheduler").shared().pause();
+
+    defineTestClass();
+
+    await testMaterializationIsStoreNeutralButUiVisible();
+    await testThrowingSetterRestoresStub();
+
+    console.log("\n" + passed + " passed, " + failed + " failed");
+    process.exit(failed === 0 ? 0 : 1);
+}
+
+main().catch((e) => {
+    console.error("BOOT FAILURE:", e);
+    process.exit(1);
+});

--- a/tests/headless/TestLazyMaterializationNeutrality.js
+++ b/tests/headless/TestLazyMaterializationNeutrality.js
@@ -15,21 +15,21 @@
  *   - Materializing IS an event with respect to the UI — memory's shape
  *     changed, views must re-sync — so didUpdateNode still fires and bubbles.
  *
- * Mechanism under test:
- *   - Slot.isMaterializingAnyLazySlot(): a STATIC counter bracketing the
- *     setter write-back in onInstanceMaterializeLazySlot. Static because the
- *     side effects cross object boundaries (the bubble dirties ANCESTORS,
- *     whose per-instance isMaterializingLazySlot flag is false); a counter
- *     because materializations can nest. Single-threaded JS makes the
- *     attribution sound: anything that fires inside the synchronous window
- *     was caused by the materialization.
- *   - didMutate still FIRES normally (it is an honest "memory changed"
- *     broadcast); the STORE's policy lives at the receiver:
- *     SvObjectPool.onDidMutateObject declines addDirtyObject during
- *     materialization.
- *   - SvSyncableJsonGroup/SvSyncableArrayNode.touchLocalModified() are no-ops
- *     during materialization (the timestamp write is direct store-facing
- *     state; no receiver can intercept it).
+ * Mechanism under test — two narrowly-scoped echo filters:
+ *   - PER-INSTANCE: the materializing object's own didMutate is skipped
+ *     (SvStorableNode.didMutate + isMaterializingLazySlot) — its state IS the
+ *     stored state being written back. Deliberately per-instance so objects
+ *     genuinely CREATED or changed by hooks during someone else's
+ *     materialization still broadcast and get stored (a blanket time-window
+ *     filter at the pool would drop them — never-stored objects have no other
+ *     path into the store).
+ *   - GLOBAL: Slot.isMaterializingAnyLazySlot(), a STATIC counter bracketing
+ *     the setter write-back — needed because the didUpdateNode bubble reaches
+ *     ANCESTORS whose per-instance flag is false. Consulted ONLY by
+ *     SvSyncableJsonGroup/SvSyncableArrayNode.touchLocalModified() (loading is
+ *     not a local modification; the cloud timestamp must not move). A counter
+ *     because materializations can nest; single-threaded JS makes the
+ *     attribution sound.
  *   - A throwing setter restores the SvStoreRef stub (catch + rethrow), so a
  *     failed materialization is retryable instead of leaving the slot
  *     permanently null.
@@ -170,6 +170,46 @@ async function testMaterializationIsStoreNeutralButUiVisible () {
     check(doc.localLastModified() > timestampBaseline, "control: a genuine didUpdateNode still touches localLastModified");
 }
 
+async function testNewObjectCreatedDuringMaterializationStillStores () {
+    console.log("\nAn object genuinely CREATED by a hook during materialization is still dirtied and stored");
+
+    const pool = newPool();
+    const doc = TestLazyDocument.clone();
+
+    pool.addActiveObject(doc);
+    pool.addActiveObject(doc.section());
+    pool.dirtyObjects().set(doc.puuid(), doc);
+    pool.dirtyObjects().set(doc.section().puuid(), doc.section());
+    await pool.commitStoreDirtyObjects();
+
+    stubSectionSlot(pool, doc);
+    pool.dirtyObjects().clear();
+
+    // Hook side effect INSIDE the write-back window: create a brand-new
+    // stored object (a blanket time-window dirty filter would drop it — the
+    // store has never seen it, so its didMutate is its only path to being
+    // persisted).
+    let created = null;
+    const realHook = doc.didUpdateSlotSection.bind(doc);
+    doc.didUpdateSlotSection = function (oldValue, newValue) {
+        if (created === null) {
+            created = SvGlobals.get("SvJsonGroup").clone();
+            pool.addActiveObject(created);
+            created.didMutate(); // genuinely new state announcing itself
+        }
+        return realHook(oldValue, newValue);
+    };
+
+    doc.section(); // materialize
+
+    check(created !== null, "hook ran during materialization and created a new object");
+    check(pool.dirtyObjects().has(created.puuid()), "the NEW object was marked dirty despite the materialization window");
+    check(!pool.dirtyObjects().has(doc.puuid()), "…while the materializing doc's own write-back echo was still filtered");
+
+    await pool.commitStoreDirtyObjects();
+    check(pool.kvMap().hasKey(created.puuid()), "the new object was stored by the next commit");
+}
+
 async function testThrowingSetterRestoresStub () {
     console.log("\nA throwing setter restores the stub (failure is retryable, exception propagates)");
 
@@ -219,6 +259,7 @@ async function main () {
     defineTestClass();
 
     await testMaterializationIsStoreNeutralButUiVisible();
+    await testNewObjectCreatedDuringMaterializationStillStores();
     await testThrowingSetterRestoresStub();
 
     console.log("\n" + passed + " passed, " + failed + " failed");

--- a/tests/headless/TestLazyMaterializationNeutrality.js
+++ b/tests/headless/TestLazyMaterializationNeutrality.js
@@ -213,6 +213,63 @@ async function testNewObjectCreatedDuringMaterializationStillStores () {
     check(pool.kvMap().hasKey(created.puuid()), "the new object was stored by the next commit");
 }
 
+async function testMissingRecordFailureHandling () {
+    console.log("\nMissing record: null return (or hook fallback), SvStoreRef stays, negative cache latches, no store dirt or cloud touch");
+
+    const SvStoreRef = SvGlobals.get("SvStoreRef");
+    const pool = newPool();
+    const doc = TestLazyDocument.clone();
+
+    await storeDocAndSection(pool, doc);
+
+    // Point the slot's ref at a pid the pool has no record for.
+    const ref = placeStoreRefInSectionSlot(pool, doc);
+    ref.setPid("bogus_missing_pid_123");
+    doc.setLocalLastModified(12345);
+    pool.dirtyObjects().clear();
+    const timestampBaseline = doc.localLastModified();
+
+    // Access 1: fresh attempt — hits the pool, fails, records the attempt.
+    const result1 = doc.section();
+    check(result1 === null, "getter returned null on missing record (no hook defined)");
+    check(doc.thisPrototype().slotNamed("section").onInstanceRawGetValue(doc) instanceof SvStoreRef, "SvStoreRef still in the slot (failure never written through the setter)");
+    check(ref.attemptCount() === 1, "attempt recorded on the ref");
+    check(ref.lastErrorKind() === "missingRecord", "error kind classified as missingRecord");
+    check(pool.dirtyObjects().size === 0, "no object marked dirty by the failed materialization");
+
+    // Access 2 (immediate → inside the negative-cache window): no new pool
+    // attempt, same result.
+    const result2 = doc.section();
+    check(result2 === null, "latched access still returns null");
+    check(ref.attemptCount() === 1, "negative cache: no second pool attempt inside the window");
+
+    // Define the owner hook: capture context, substitute a fallback, and
+    // write it through the setter (the store-neutral repair path).
+    const SvJsonGroup = SvGlobals.get("SvJsonGroup");
+    let hookContext = null;
+    const fallback = SvJsonGroup.clone();
+    doc.onFailedLazyLoadSlotSection = function (context) {
+        hookContext = context;
+        context.result = fallback;
+        this.setSection(fallback);
+    };
+
+    // Access 3 (still latched): hook runs anyway — the latch rate-limits pool
+    // lookups, not the hook.
+    const result3 = doc.section();
+    check(result3 === fallback, "hook override: latched access returned the hook's fallback");
+    check(hookContext !== null && hookContext.errorKind === "missingRecord" && hookContext.storeRef === ref && hookContext.slotName === "section", "hook received the full context (errorKind, storeRef, slotName)");
+    check(ref.attemptCount() === 1, "hook invocation did not count as a pool attempt");
+
+    // The hook's setter write replaced the SvStoreRef — and was store-neutral.
+    check(doc.thisPrototype().slotNamed("section").onInstanceRawGetValue(doc) === fallback, "hook's setter write landed in the slot (subsequent accesses skip the failure path)");
+    check(pool.dirtyObjects().size === 0, "fallback write is store-neutral: nothing marked dirty (oldValue was the SvStoreRef)");
+    check(doc.localLastModified() === timestampBaseline, "fallback write did not touch localLastModified (hook runs inside the materialization counter)");
+
+    const result4 = doc.section();
+    check(result4 === fallback, "next access returns the fallback directly (real slot value now)");
+}
+
 async function testThrowingSetterLeavesStoreRefInPlace () {
     console.log("\nA throwing setter leaves the SvStoreRef in place (failure is retryable, exception propagates)");
 
@@ -258,6 +315,7 @@ async function main () {
 
     await testMaterializationIsStoreNeutralButUiVisible();
     await testNewObjectCreatedDuringMaterializationStillStores();
+    await testMissingRecordFailureHandling();
     await testThrowingSetterLeavesStoreRefInPlace();
 
     console.log("\n" + passed + " passed, " + failed + " failed");

--- a/tests/headless/TestMidStoreMutationDefer.js
+++ b/tests/headless/TestMidStoreMutationDefer.js
@@ -1,0 +1,216 @@
+#!/usr/bin/env node
+
+"use strict";
+
+/**
+ * Headless test: an object mutated DURING the store pass no longer aborts the
+ * commit ("attempt to double store <id>") — it is tripwire-logged with the
+ * mutation-time stack and re-queued so the NEXT commit stores the fresh state.
+ *
+ * Two paths, matching the two detection points in SvObjectPool:
+ *   1. Mutated AFTER its own store turn (addDirtyObject sees the pid in
+ *      storingPids → defers immediately).
+ *   2. Mutated BEFORE its own store turn but after entering the pass's bucket
+ *      (addDirtyObject can't flag it; the loop guard finds the pid already in
+ *      storingPids on the next loop → defers with the stack captured at
+ *      mutation time).
+ * Plus: forceAddDirtyObject's old silent skip of already-stored objects is now
+ * the same defer (the skip dropped the change, leaving a stale record).
+ *
+ * Mutating during a store pass is still a defect to hunt at its source — the
+ * TRIPWIRE console.error (which reaches error reports) carries the culprit's
+ * stack. This test asserts the failure containment, not the culprits.
+ *
+ * Usage (from the strvct root):
+ *   node source/boot/index-builder/ImportsIndexer.js   # if index is stale
+ *   node tests/headless/TestMidStoreMutationDefer.js
+ */
+
+const path = require("path");
+const { pathToFileURL } = require("url");
+
+// Boot expects cwd to be the site root (build/_index.json lives there).
+const strvctRoot = path.join(__dirname, "..", "..");
+process.chdir(strvctRoot);
+
+let passed = 0;
+let failed = 0;
+
+function check (condition, message) {
+    if (condition) {
+        passed++;
+        console.log("  \x1b[32m✓\x1b[0m " + message);
+    } else {
+        failed++;
+        console.log("  \x1b[31m✗\x1b[0m " + message);
+    }
+}
+
+async function boot () {
+    const bootFile = (p) => import(pathToFileURL(path.join(strvctRoot, p)).href);
+    await bootFile("source/boot/SvGlobals.js");
+    await bootFile("source/boot/SvPlatform.js");
+    await bootFile("source/boot/StrvctFile.js");
+    await bootFile("source/boot/SvBootLoader.js");
+
+    const SvBootLoader = SvGlobals.get("SvBootLoader");
+    SvBootLoader._bootPath = "source/boot";
+    await SvBootLoader.asyncRun();
+}
+
+// --- helpers -------------------------------------------------------------
+
+function newPool () {
+    return SvGlobals.get("SvObjectPool").clone();
+}
+
+function newStoredDoc (pool) {
+    const doc = SvGlobals.get("SvSyncableJsonGroup").clone();
+    pool.addActiveObject(doc);
+    pool.dirtyObjects().set(doc.puuid(), doc);
+    return doc;
+}
+
+// Wrap console.error to capture tripwire lines for the duration of fn.
+async function captureTripwires (fn) {
+    const tripwires = [];
+    const realError = console.error;
+    console.error = function (...args) {
+        const line = args.join(" ");
+        if (line.includes("TRIPWIRE")) {
+            tripwires.push(line);
+            return; // keep the test output readable
+        }
+        return realError.apply(console, args);
+    };
+    try {
+        await fn();
+    } finally {
+        console.error = realError;
+    }
+    return tripwires;
+}
+
+// Make storing `mutator` set cloudLastModified on `victim` — a genuine write
+// to a stored slot, mid-pass, from inside the store walk.
+function sabotageStoreToMutate (mutator, victim, value) {
+    const realFn = mutator.thisClass().prototype.recordForStore;
+    mutator.recordForStore = function (aStore) {
+        victim.setCloudLastModified(value);
+        return realFn.call(this, aStore);
+    };
+}
+
+// Records serialize slots as an entries array: { type, entries: [[k, v]…], id }
+function storedSlotValue (pool, pid, slotName) {
+    const record = pool.recordForPid(pid);
+    if (!record || !record.entries) {
+        return undefined;
+    }
+    const entry = record.entries.find(e => e[0] === slotName);
+    return entry ? entry[1] : undefined;
+}
+
+// --- tests ---------------------------------------------------------------
+
+async function testMutatedAfterItsStoreTurn () {
+    console.log("\nPath 1: object mutated AFTER its store turn — deferred, next commit stores the fresh state");
+
+    const pool = newPool();
+    const victim = newStoredDoc(pool);  // inserted first → stored first
+    const mutator = newStoredDoc(pool); // its serialization mutates victim
+
+    sabotageStoreToMutate(mutator, victim, 777);
+
+    let threw = null;
+    const tripwires = await captureTripwires(async () => {
+        try {
+            await pool.commitStoreDirtyObjects();
+        } catch (e) {
+            threw = e;
+        }
+    });
+
+    check(threw === null, "commit completed without the double-store throw");
+    check(tripwires.length === 1, "exactly one TRIPWIRE logged");
+    check(tripwires.length > 0 && tripwires[0].includes("SvSyncableJsonGroup"), "tripwire names the mutated object's type");
+    check(tripwires.length > 0 && tripwires[0].includes("TestMidStoreMutationDefer"), "tripwire carries the mutation-time stack (names the culprit frame)");
+    check(pool.dirtyObjects().has(victim.puuid()), "mutated object re-queued for the next commit");
+    check(storedSlotValue(pool, victim.puuid(), "cloudLastModified") === null, "this pass's record is stale (pre-mutation) — the defer exists precisely because of this");
+
+    await pool.commitStoreDirtyObjects();
+    check(storedSlotValue(pool, victim.puuid(), "cloudLastModified") === 777, "next commit stored the fresh (post-mutation) state");
+    check(pool.dirtyObjects().size === 0, "no residual dirt after the follow-up commit");
+}
+
+async function testMutatedBeforeItsStoreTurn () {
+    console.log("\nPath 2: object mutated before its store turn (same bucket) — loop guard defers instead of throwing");
+
+    const pool = newPool();
+    const mutator = newStoredDoc(pool); // inserted first → stored first
+    const victim = newStoredDoc(pool);  // mutated during mutator's store, then stored in the same bucket
+
+    sabotageStoreToMutate(mutator, victim, 888);
+
+    let threw = null;
+    const tripwires = await captureTripwires(async () => {
+        try {
+            await pool.commitStoreDirtyObjects();
+        } catch (e) {
+            threw = e;
+        }
+    });
+
+    check(threw === null, "commit completed without the double-store throw");
+    check(tripwires.length === 1, "exactly one TRIPWIRE logged");
+    check(tripwires.length > 0 && tripwires[0].includes("TestMidStoreMutationDefer"), "loop-guard tripwire still carries the mutation-time stack (captured at add time)");
+    check(storedSlotValue(pool, victim.puuid(), "cloudLastModified") === 888, "victim's stored record has the mutation (it stored after being mutated)");
+
+    await pool.commitStoreDirtyObjects(); // drains the deferred re-queue (same value — harmless)
+    check(pool.dirtyObjects().size === 0, "no residual dirt after the follow-up commit");
+}
+
+async function testSelfMutatingSerializerGivesUpAfterCap () {
+    console.log("\nPathology: a serializer that mutates its OWN stored slots re-defers, then gives up after the cap (no endless commit loop)");
+
+    const pool = newPool();
+    const doc = newStoredDoc(pool);
+    const realFn = doc.thisClass().prototype.recordForStore;
+    doc.recordForStore = function (aStore) {
+        doc.setCloudLastModified((doc.cloudLastModified() || 0) + 1); // mutates itself on every serialization
+        return realFn.call(this, aStore);
+    };
+
+    let commits = 0;
+    const tripwires = await captureTripwires(async () => {
+        while (pool.dirtyObjects().size > 0 && commits < 10) {
+            await pool.commitStoreDirtyObjects();
+            commits++;
+        }
+    });
+
+    check(commits < 10, "commit cycle terminated (" + commits + " commits) instead of looping forever");
+    check(pool.dirtyObjects().size === 0, "no dirt left after giving up");
+    check(tripwires.some(t => t.includes("giving up")), "the final tripwire says it gave up on the self-mutator");
+}
+
+async function main () {
+    console.log("TestMidStoreMutationDefer: booting strvct…");
+    await boot();
+
+    // Isolate from the scheduler's fire-and-forget auto-commits; we drive
+    // commitStoreDirtyObjects() explicitly.
+    SvGlobals.get("SvSyncScheduler").shared().pause();
+
+    await testMutatedAfterItsStoreTurn();
+    await testMutatedBeforeItsStoreTurn();
+    await testSelfMutatingSerializerGivesUpAfterCap();
+
+    console.log("\n" + passed + " passed, " + failed + " failed");
+    process.exit(failed === 0 ? 0 : 1);
+}
+
+main().catch((e) => {
+    console.error("BOOT FAILURE:", e);
+    process.exit(1);
+});


### PR DESCRIPTION
## The invariant

Materializing a lazy slot is **not a mutation with respect to the store** — the store already contains exactly the value being loaded — but it **is an event with respect to the UI** (memory's shape changed; views must re-sync). The pre-existing design couldn't express that: the mutation system has one class of mutation, so materialization echoes dirtied the enclosing `SvSyncableJsonGroup` and bumped its `localLastModified` — a spurious cloud push of an unchanged document on every sheet open, and (mid-store-pass) very likely the "attempt to double store" crash behind #36.

## The design: derive the classification from data, not flags

The root enabler: `Slot.onInstanceMaterializeLazySlot` previously **pre-cleared** the `SvStoreRef` placeholder before the setter write (added in `0bdeefb4` to spare `didUpdateSlotSubnodes` from placeholder-typed `oldValue`s) — destroying the one unforgeable record that the write was a load. This PR removes the pre-clear: **the `SvStoreRef` survives to the setter, so `didUpdateSlot` receives it as `oldValue`**, and the `SvStoreRef → value` transition — which no user or app code can produce — *is* the classification:

- `SvStorableNode.didUpdateSlot`: `didMutate` skipped when `oldValue instanceof SvStoreRef`. No flags.
- `SvNode.didUpdateSlotSubnodes` (audited: the **only** live `oldValue` consumer for any lazy slot): skips `removeMutationObserver` for a placeholder (it was never observed) and runs only the UI half of `didChangeSubnodeList` on materialization (`didUpdateNode` yes, `didMutate("subnodes")` no).
- Objects genuinely **created or changed by hooks during someone else's materialization** emit ordinary transitions and are dirtied/stored normally — no time-window over-suppression.
- Throwing setters need no restore logic anymore: nothing was cleared, so the `SvStoreRef` is still in place and the next access retries.
- The per-instance `isMaterializingLazySlot` flag is **removed** (zero consumers remain).
- `Slot.isMaterializingAnyLazySlot()` (static counter) survives for exactly **one** consumer: `SvSyncable*.touchLocalModified()` — the `didUpdateNode` bubble carries no `oldValue`, so the cross-object cloud-timestamp echo can't be derived. `_suppressLocalModifiedTouch` is untouched (sync-alignment echoes are a different, non-derivable class).
- `setIsLazy` now documents the hook contract: a `didUpdateSlot<Name>` hook on a lazy slot may receive an `SvStoreRef` as `oldValue` (violations fail loud — immediate TypeError — not silent).

## Testing

`TestLazyMaterializationNeutrality.js` (18 checks): store-neutral (no dirty, `localLastModified` unmoved) + UI-visible (`didUpdateNode` bubbles) + **derived-evidence assertion** (the slot hook receives the `SvStoreRef` as `oldValue`) + a hook-created brand-new object during materialization is still dirtied and stored + throwing setter leaves the `SvStoreRef` in place and retries + controls proving genuine changes still dirty/touch.

Verified negatively (earlier revision): against unfixed source the test reproduces the spurious `localLastModified` bump.

Regression suites green against rebuilt cams: TestSlotLazyLoading 34/0 (GameServer — exercises lazy-subnodes materialization through the changed `didUpdateSlotSubnodes`), TestBlobHashChange 21/0, TestCategorySlots 20/0. ESLint clean.

## Relation to #36

This removes the likely dominant *source* of mid-pass re-dirties (materialization echoes). Recommend #36 rebases on this and drops its `isAnyPoolStoring`-based touch-suppression (a time-window mute would now only hide real offenders), keeping its independently-correct hardening — try/finally un-poisoning, tx revert, commit re-entrancy guard, the double-store throw — plus the `addDirtyObject` tripwire from review so any remaining mid-pass mutator gets named and fixed at source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)