### PR TITLE
AiServiceKit: optional per-request customHeaders pass-through

### DIFF
--- a/source/library/services/AiServiceKit/Requests/SvAiRequest.js
+++ b/source/library/services/AiServiceKit/Requests/SvAiRequest.js
@@ -111,6 +111,19 @@
             slot.setSlotType("JSON Object");
         }
 
+        /**
+     * @member {Object} customHeaders - Optional per-request headers merged into the
+     *   outgoing request headers just before the XHR is sent. App-agnostic transport:
+     *   the framework forwards whatever dict is set here and knows nothing of its
+     *   contents. Default null → no header, no behavior change.
+     */
+        {
+            const slot = this.newSlot("customHeaders", null);
+            slot.setSlotType("JSON Object");
+            slot.setShouldStoreSlot(false);
+            slot.setAllowsNullValue(true);
+        }
+
 
         /**
      * @member {Boolean} isStreaming - Whether the request is streaming.
@@ -624,6 +637,13 @@
 
         // Get request options and URL asynchronously
         const requestOptions = await this.requestOptions();
+        // Merge any caller-supplied per-request headers here, at the single seam
+        // where every subclass' requestOptions() result is consumed, so it covers
+        // subclasses that override requestOptions() (e.g. SvGeminiRequest) without
+        // touching each override. Default null → no-op.
+        if (this.customHeaders()) {
+            Object.assign(requestOptions.headers, this.customHeaders());
+        }
         const apiUrl = await this.activeApiUrl();
 
         // Configure the XHR request

--- a/source/library/services/AiServiceKit/SvAiResponseMessage.js
+++ b/source/library/services/AiServiceKit/SvAiResponseMessage.js
@@ -300,6 +300,19 @@
         json.messages = this.jsonHistory();
 
         request.setBodyJson(json);
+
+        // App-agnostic hook: let the conversation supply per-request headers
+        // (e.g. usage attribution) for the requests it spawns. Duck-typed so the
+        // framework stays app-blind — a conversation that does not implement it
+        // yields no header and no behavior change.
+        const conversation = this.conversation();
+        if (conversation && typeof conversation.aiRequestCustomHeaders === "function") {
+            const headers = conversation.aiRequestCustomHeaders();
+            if (headers) {
+                request.setCustomHeaders(headers);
+            }
+        }
+
         return request;
     }
 

--- a/source/library/services/ImaginePro/Image Eval Prompts/SvImageEvaluator/SvImageEvaluator.js
+++ b/source/library/services/ImaginePro/Image Eval Prompts/SvImageEvaluator/SvImageEvaluator.js
@@ -137,6 +137,19 @@
             slot.setDescription("XHR request used for Gemini API call");
         }
 
+        /**
+     * @member {Object} customHeaders
+     * @description Optional per-request headers forwarded to the Gemini
+     *   evaluation request. App-agnostic pass-through; default null → no header.
+     * @category Request
+     */
+        {
+            const slot = this.newSlot("customHeaders", null);
+            slot.setSlotType("JSON Object");
+            slot.setShouldStoreSlot(false);
+            slot.setAllowsNullValue(true);
+        }
+
 
         // Action to evaluate the image
     /*
@@ -391,6 +404,7 @@
         const evalModel = service.models().subnodes().detect(m => m.modelName() === "gemini-3.1-flash-lite-preview") || service.defaultChatModel();
         request.setChatModel(evalModel);
         request.setBodyJson(bodyJson);
+        request.setCustomHeaders(this.customHeaders()); // usage attribution for the eval call
         request.setIsStreaming(false); // We want the complete response, not streaming
         request.setTimeoutPeriodInMs(30 * 60 * 1000); // 30 minutes for vision API (can be slow)
 

--- a/source/library/services/ImaginePro/Image Eval Prompts/SvImagineProImageEvalPrompt.js
+++ b/source/library/services/ImaginePro/Image Eval Prompts/SvImagineProImageEvalPrompt.js
@@ -161,6 +161,7 @@
                 const evaluator = this.imageEvaluators().add();
                 evaluator.setSvImage(fileToDownload.imageNode());
                 evaluator.setImageGenPrompt(this.prompt());
+                evaluator.setCustomHeaders(this.customHeaders()); // forward attribution to the Gemini eval request
             }
 
             this.setStatus("Evaluating images...");

--- a/source/library/services/ImaginePro/Text to Image/SvImagineProImageGeneration.js
+++ b/source/library/services/ImaginePro/Text to Image/SvImagineProImageGeneration.js
@@ -103,6 +103,19 @@
         }
 
         /**
+     * @member {Object} customHeaders
+     * @description Optional per-request headers forwarded to the status-poll
+     *   requests. App-agnostic pass-through; default null → no header.
+     * @category Configuration
+     */
+        {
+            const slot = this.newSlot("customHeaders", null);
+            slot.setSlotType("JSON Object");
+            slot.setShouldStoreSlot(false);
+            slot.setAllowsNullValue(true);
+        }
+
+        /**
      * @member {number} pollInterval
      * @description The interval in milliseconds between polls.
      * @category Configuration
@@ -254,10 +267,14 @@
             const request = SvXhrRequest.clone();
             request.setUrl(proxyEndpoint);
             request.setMethod("GET");
-            request.setHeaders({
+            const headers = {
                 "Authorization": `Bearer ${apiKey}`
                 // Don't send Content-Type for GET requests - it causes Firebase to return 400
-            });
+            };
+            if (this.customHeaders()) {
+                Object.assign(headers, this.customHeaders());
+            }
+            request.setHeaders(headers);
 
             await request.asyncSend();
 

--- a/source/library/services/ImaginePro/Text to Image/SvImagineProImagePrompt.js
+++ b/source/library/services/ImaginePro/Text to Image/SvImagineProImagePrompt.js
@@ -559,6 +559,21 @@ Midjourney
             //slot.setIsInCloudJson(false); // Delegates are runtime refs, would create circular references
         }
 
+        /**
+     * @member {Object} customHeaders
+     * @description Optional per-request headers forwarded to every request this
+     *   prompt spawns — the generation submit, the status polls, and (in the eval
+     *   subclass) the image-evaluation requests. App-agnostic pass-through;
+     *   default null → no header, no behavior change.
+     * @category Request Data
+     */
+        {
+            const slot = this.newSlot("customHeaders", null);
+            slot.setSlotType("JSON Object");
+            slot.setShouldStoreSlot(false);
+            slot.setAllowsNullValue(true);
+        }
+
 
         /**
          * @member {Action} newSeedAction
@@ -930,10 +945,10 @@ Midjourney
         request.setDelegate(this);
         request.setUrl(proxyEndpoint);
         request.setMethod("POST");
-        request.setHeaders({
+        request.setHeaders(this.headersWithCustom({
             "Authorization": `Bearer ${apiKey}`,
             "Content-Type": "application/json"
-        });
+        }));
 
         const fullPrompt = await this.asyncComposeFullPrompt();
 
@@ -956,10 +971,10 @@ Midjourney
                 request.setDelegate(this);
                 request.setUrl(proxyEndpoint);
                 request.setMethod("POST");
-                request.setHeaders({
+                request.setHeaders(this.headersWithCustom({
                     "Authorization": `Bearer ${apiKey}`,
                     "Content-Type": "application/json"
-                });
+                }));
                 request.setBody(JSON.stringify(bodyJson));
                 this.setXhrRequest(request);
             }
@@ -1017,7 +1032,22 @@ Midjourney
         generation.setPromptNote(fullPrompt);
         generation.setTaskId(taskId);
         generation.setDelegate(this);
+        generation.setCustomHeaders(this.customHeaders()); // status polls carry the same attribution
         await generation.asyncStartPolling();
+    }
+
+    /**
+   * @description Returns a copy of the given headers dict with any per-request
+   *   customHeaders merged in. App-agnostic pass-through helper.
+   * @param {Object} headers - The base headers dict.
+   * @returns {Object} The headers dict with customHeaders merged.
+   * @category Request Preparation
+   */
+    headersWithCustom (headers) {
+        if (this.customHeaders()) {
+            return Object.assign({}, headers, this.customHeaders());
+        }
+        return headers;
     }
 
     /**

--- a/source/library/services/OpenAI/Text to Speech/SvOpenAiTtsRequest.js
+++ b/source/library/services/OpenAI/Text to Speech/SvOpenAiTtsRequest.js
@@ -58,6 +58,19 @@
         }
 
         /**
+     * @member {Object} customHeaders - Optional per-request headers merged into the
+     *   outgoing request headers. App-agnostic pass-through: the framework forwards
+     *   whatever dict is set here. Default null → no header, no behavior change.
+     * @category Request Data
+     */
+        {
+            const slot = this.newSlot("customHeaders", null);
+            slot.setSlotType("JSON Object");
+            slot.setShouldStoreSlot(false);
+            slot.setAllowsNullValue(true);
+        }
+
+        /**
      * @member {String} body - The stringified version of bodyJson.
      * @category Request Data
      */
@@ -214,10 +227,14 @@
         const xhr = SvXhrRequest.clone();
         xhr.setUrl(this.proxyUrl());
         xhr.setMethod("POST");
-        xhr.setHeaders({
+        const headers = {
             "Content-Type": "application/json",
             "Authorization": `Bearer ${await this.service().apiKeyOrUserAuthToken()}`
-        });
+        };
+        if (this.customHeaders()) {
+            Object.assign(headers, this.customHeaders());
+        }
+        xhr.setHeaders(headers);
         xhr.setDelegate(this);
         xhr.setBody(JSON.stringify(this.bodyJson()));
         xhr.setResponseType("blob"); // Set to blob for binary audio data

--- a/source/library/services/OpenAI/Text to Speech/SvOpenAiTtsSession.js
+++ b/source/library/services/OpenAI/Text to Speech/SvOpenAiTtsSession.js
@@ -282,6 +282,18 @@
             slot.setSlotType("Object");
         }
 
+        {
+            /**
+       * @member {Object} customHeaders
+       * @description Optional per-request headers forwarded to each TTS request
+       *   this session spawns. App-agnostic pass-through; default null → no header.
+       */
+            const slot = this.newSlot("customHeaders", null);
+            slot.setSlotType("JSON Object");
+            slot.setShouldStoreSlot(false);
+            slot.setAllowsNullValue(true);
+        }
+
         this.setShouldStore(true);
         this.setShouldStoreSubnodes(false);
         this.setSubnodeClasses([]);
@@ -399,6 +411,7 @@
         const request = SvOpenAiTtsRequest.clone();
         request.setApiUrl(this.endpoint());
         request.setDelegate(this);
+        request.setCustomHeaders(this.customHeaders());
 
         const bodyJson = {
             model: this.ttsModel(),


### PR DESCRIPTION
## What

Adds an app-agnostic transport for attaching **opaque per-request headers** to outgoing AI requests across AiServiceKit, OpenAI TTS, and ImaginePro, with **zero behavior change when unset**.

- **`SvAiRequest`** — new null-default `customHeaders` JSON slot, merged into the outgoing request headers at the single send seam (`asyncSendAndStreamResponse`), so it covers subclasses that override `requestOptions()` without touching each.
- **`SvAiResponseMessage.newRequest()`** — duck-typed hook: if the conversation implements `aiRequestCustomHeaders()`, its result is set on the request. The framework stays app-blind; a conversation that does not implement it yields no header.
- **OpenAI TTS** — `SvOpenAiTtsSession` / `SvOpenAiTtsRequest` gain the same pass-through; the session forwards its `customHeaders` to each request it spawns.
- **ImaginePro** — `SvImagineProImagePrompt` / `SvImagineProImageGeneration` forward `customHeaders` to the generation submit and the status-poll requests; `SvImagineProImageEvalPrompt` / `SvImageEvaluator` forward them to the Gemini image-evaluation requests.

## Why

Lets an application attach opaque per-request headers (e.g. usage attribution) to the AI calls it makes, without the framework knowing the header's name or contents. Transport only — the app decides what to put in it.

## Guarantee

Every new slot defaults to `null` (no header emitted, no behavior change) and is marked `shouldStoreSlot(false)`. When nothing populates `customHeaders`, outgoing requests are byte-identical to today.

## Note

An application PR consumes this — it populates the header dict via the `aiRequestCustomHeaders()` hook and the TTS/ImaginePro `customHeaders` slots. No app internals are required here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)