### PR TITLE
Fix silent-hang paths in blob store + image-generation polling

### DIFF
--- a/source/library/node/storage/base/SvBlobPool.js
+++ b/source/library/node/storage/base/SvBlobPool.js
@@ -261,16 +261,26 @@
 
             // Cache the blob for future access
             this.activeBlobs().set(hash, blob);
-            this.activeWritesMap().delete(hash);
-            writePromise.callResolveFunc(hash);
+            return hash;
         } catch (error) {
             console.error(`Error storing blob ${hash.substring(0, 8)}...: ${error.message}`);
-            this.activeWritesMap().delete(hash);
-            writePromise.callRejectFunc(error);
+            // Reject the shared promise so concurrent/later stores awaiting this
+            // hash observe the failure (before the finally's resolve-if-pending,
+            // which then no-ops on the now-settled promise).
+            writePromise.callRejectFuncIfPending(error);
             throw error;
+        } finally {
+            // Single cleanup for EVERY exit — the deduplication return, the
+            // normal-store return, and the error throw. Clear the in-flight
+            // entry and settle the shared promise so a store of the same hash
+            // that is awaiting this promise can never hang. The deduplication
+            // branch previously returned WITHOUT this cleanup, leaking a pending
+            // promise that poisoned the hash for the lifetime of the pool: every
+            // subsequent store of that content awaited a promise that would
+            // never settle.
+            this.activeWritesMap().delete(hash);
+            writePromise.callResolveFuncIfPending(hash);
         }
-
-        return hash;
     }
 
     /**

--- a/source/library/services/ImaginePro/Text to Image/SvImagineProImageGeneration.js
+++ b/source/library/services/ImaginePro/Text to Image/SvImagineProImageGeneration.js
@@ -276,6 +276,11 @@
                     this.setStatus("failed");
                     this.setError(new Error(errorMsg));
                     this.stopPolling();
+                    // Settle the awaited completionPromise (as handlePollError
+                    // does). This was previously missing, so a 400 stopped
+                    // polling but left the promise pending forever — hanging the
+                    // awaiting generate() chain and never surfacing a failure.
+                    this.completionPromise().callRejectFunc(this.error());
                     this.sendDelegateMessage("onImageGenerationError", [this]);
                 } else {
                     // Other errors, keep polling
@@ -321,13 +326,26 @@
         this.setStatus("completed");
         this.stopPolling();
 
-        // ImaginePro returns images directly in response.images
-        const imageUrls = response.images;
-        if (imageUrls && imageUrls.length > 0) {
-            await this.downloadImageUrls(imageUrls);
-        }
+        try {
+            // ImaginePro returns images directly in response.images
+            const imageUrls = response.images;
+            if (imageUrls && imageUrls.length > 0) {
+                await this.downloadImageUrls(imageUrls);
+            }
 
-        this.completionPromise().callResolveFunc(this);
+            this.completionPromise().callResolveFunc(this);
+        } catch (error) {
+            // handlePollDone is invoked WITHOUT await (from handlePollResponse),
+            // so a throw from the image downloads used to skip the resolve above
+            // and leave completionPromise pending forever — hanging the awaiting
+            // generate() chain. Settle it as a rejection instead, matching
+            // handlePollError.
+            const normalizedError = Error.normalizeError(error);
+            this.setStatus("failed");
+            this.setError(normalizedError);
+            this.completionPromise().callRejectFunc(normalizedError);
+            this.sendDelegateMessage("onImageGenerationError", [this]);
+        }
     }
 
     async downloadImageUrls (imageUrls) {
@@ -378,6 +396,11 @@
             this.setStatus("timeout");
             this.setError(new Error("Task timed out after " + this.maxPollAttempts() + " attempts"));
             this.stopPolling();
+            // Settle the awaited completionPromise (as handlePollError does).
+            // This was previously missing, so exhausting the poll attempts
+            // stopped polling but left the promise pending forever — hanging
+            // the awaiting generate() chain and never surfacing a failure.
+            this.completionPromise().callRejectFunc(this.error());
             this.sendDelegateMessage("onImageGenerationError", [this]);
         } else {
             const timeoutId = setTimeout(() => this.pollTaskStatus(), this.pollInterval());


### PR DESCRIPTION
> [!NOTE]
> Dean's review complete 2026-07-27.

Companion to undreamedof/undreamedof.ai#467 (multiplayer image sharing). Two framework-level silent-hang fixes found while root-causing intermittent "image never completes" stalls (~25% of real generations in diagnostics):

1. **`SvBlobPool.asyncStoreBlob` — dedup promise leak (the firing bug).** The already-in-IDB early return exited without settling the in-flight write promise or clearing `activeWritesMap`, permanently poisoning that hash: any later store of the same content awaited the dead promise forever. All exits now settle + clear via `finally` with `callResolve/RejectFuncIfPending`. Reproduced: 3/12 clean real generations stalled pre-fix (host had the image; the awaited `asyncSetBlobValue` never returned); 0/12 post-fix.

2. **`SvImagineProImageGeneration` — three terminal branches never settled `completionPromise`** (poll-attempts exhausted, 400 poll response, throw from unawaited `handlePollDone`), each firing only `sendDelegateMessage("onImageGenerationError")` which no delegate implements (silent no-op). They now reject like `handlePollError` does, so errors propagate to the caller's normal failure handling.

**Convention note**: repo convention is strvct changes land on `master` with a submodule pointer bump rather than a side branch — this PR exists because Dean asked for reviewable drafts; merge or cherry-pick to master as preferred. The app-side submodule pointer currently references this branch's commit.

Verified by the app repo's e2e suite (deterministic double-store dedup test, forced poll-stall test, plus 12 clean real generations with 0 stalls vs 3/12 pre-fix; larger confirmation runs in progress).

🤖 Generated with [Claude Code](https://claude.com/claude-code)