### PR TITLE
Cap image-eval vision request timeout at 2 minutes

### DIFF
--- a/source/library/services/ImaginePro/Image Eval Prompts/SvImageEvaluator/SvImageEvaluator.js
+++ b/source/library/services/ImaginePro/Image Eval Prompts/SvImageEvaluator/SvImageEvaluator.js
@@ -392,7 +392,10 @@
         request.setChatModel(evalModel);
         request.setBodyJson(bodyJson);
         request.setIsStreaming(false); // We want the complete response, not streaming
-        request.setTimeoutPeriodInMs(30 * 60 * 1000); // 30 minutes for vision API (can be slow)
+        request.setTimeoutPeriodInMs(2 * 60 * 1000); // 2 min: instrumented runs show healthy image evals
+        // complete in seconds; this bound exists so a wedged vision call fails fast enough for the
+        // caller's own generation deadline to matter (a 30-minute allowance made every outer
+        // timeout meaningless and looked like a hang to the user).
 
         // Store reference to underlying XHR for debugging
         this.setSvXhrRequest(request.currentXhrRequest());


### PR DESCRIPTION
Follow-up to #39. The Gemini image-eval XHR allowed **30 minutes** ("vision API can be slow"), which made every outer deadline meaningless — a wedged vision call presented to the user as an indefinite hang, and the app-side generation watchdog had to be set conservatively long just to stay outside this bound.

Instrumented data (44 real Midjourney generations across local + cloud dev): healthy evals complete in **seconds**; the slowest full generation end-to-end was 198.5s with eval a small fraction of that. 2 minutes is a generous multiple of observed reality. On timeout the request throws through the existing error path (`asyncEvaluate` catch → generation fails visibly with `generationFailed`), so the failure is clean, not a new behavior.

With this in place the app-side generation deadline (currently 6 min) finally sits *outside* all inner bounds: submit ≤ ~4 min worst-case with retries, poll ≤ ~4 min, downloads ≤ 2 min each, eval ≤ 2 min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)