### PR TITLE
SvFileToDownload: optional bearer token for proxied fetches

### DIFF
--- a/source/library/services/ImaginePro/Text to Image/files/SvFileToDownload.js
+++ b/source/library/services/ImaginePro/Text to Image/files/SvFileToDownload.js
@@ -40,6 +40,16 @@
             slot.setDescription("The URL of the page that referred to this image. This is used to track the source of the image.");
         }
 
+        // bearer token slot
+        {
+            const slot = this.newSlot("bearerToken", "");
+            slot.setSlotType("String");
+            slot.setShouldStoreSlot(false); // a short-lived credential; never persist it
+            slot.setSyncsToView(false);
+            slot.setCanEditInspection(false);
+            slot.setDescription("Optional bearer token, sent as an Authorization header for destinations that require one. Empty by default, so a plain CDN fetch stays free of a CORS preflight.");
+        }
+
         /**
      * @member {SvImageNode} imageNode
      * @description Blob-backed storage for the downloaded image. Data lives in SvBlobPool; record stores only a hash + public URL.
@@ -260,6 +270,13 @@
             if (this.refererUrl()) {
                 headers["Referer"] = this.refererUrl();
             }
+        }
+
+        // Sent only when set: some destinations require it, but adding a
+        // non-simple header to a cross-origin GET would force a needless CORS
+        // preflight on the ones that don't.
+        if (this.bearerToken()) {
+            headers["Authorization"] = "Bearer " + this.bearerToken();
         }
 
         request.setHeaders(headers);


### PR DESCRIPTION
Small, generic capability, split out so the Krea PR on top is only about Krea.

## Problem

A download whose `url()` points at our `/proxy` needs an `Authorization` header — the proxy verifies a Firebase ID token and 401s without one. `SvFileToDownload` sent no `Authorization` at all, so any proxied fetch failed before reaching the target.

## Change

An optional `bearerToken` slot, applied only when set.

- **Empty by default**, so a direct CDN fetch is byte-for-byte unchanged. That matters beyond tidiness: adding a non-simple header to a cross-origin GET would force a needless CORS preflight.
- **Not persisted** (`setShouldStoreSlot(false)`) — it is a short-lived credential and has no business in stored records or JSON archives.

## Why it's needed

Stacked under it: the Krea image service, whose result images are served from a host with no CORS headers and must therefore be fetched through the proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)