### PR TITLE
Krea 2 image service: prompt, job polling, and registration

### DIFF
--- a/source/library/services/Krea/SvKreaService.js
+++ b/source/library/services/Krea/SvKreaService.js
@@ -1,0 +1,122 @@
+/**
+ * @module library.services.Krea
+ */
+
+/**
+ * @class SvKreaService
+ * @extends SvAiService
+ * @classdesc SvKreaService is a service for Krea's own image generation API
+ * (api.krea.ai).
+ *
+ * Krea 2 accepts a CUSTOM TRAINED STYLE (LoRA, referenced by id) and REFERENCE
+ * IMAGES in the same request. That combination is what lets a generated scene
+ * carry both a trained art look and per-subject continuity, and it is why we
+ * talk to Krea directly rather than through a gateway that splits the two into
+ * separate endpoints.
+ *
+ * Trained styles are PRIVATE to the API key that created them, so a style id is
+ * inert without our server-side key — which is why the id lives in a normal
+ * (inspectable, tunable) slot on the prompt rather than behind the proxy.
+ *
+ * All requests go through the proxy for accounting, key management, and CORS.
+ */
+"use strict";
+
+(class SvKreaService extends SvAiService {
+
+    /**
+     * @static
+     * @description Initializes the class and sets it as a singleton.
+     * @category Initialization
+     */
+    static initClass () {
+        this.setIsSingleton(true);
+
+        // Base URL for the Krea API, overridable globally at the app level (the
+        // same escape hatch SvImagineProImagePrompt.endpointBase provides).
+        this.newClassSlot("endpointBase", "https://api.krea.ai/");
+    }
+
+    serviceInfo () {
+        return {
+            "taskEndpoint": this.thisClass().endpointBase() + "generate/image/krea/"
+        };
+    }
+
+    /**
+     * @description Returns an array of model configurations. These mirror the
+     * three Krea 2 tiers registered in the backend KreaService pricing table —
+     * a model missing there is rejected by the proxy, so the two lists must
+     * stay in step.
+     * @returns {Array<Object>} An array of model objects.
+     * @category Model Configuration
+     */
+    modelsJson () {
+        return [
+            {
+                "name": "krea-2/medium-turbo",
+                "title": "Krea 2 Medium Turbo",
+                "inputTokenLimit": 4000,
+                "outputTokenLimit": 4000,
+                "supportsImageGeneration": true
+            },
+            {
+                "name": "krea-2/medium",
+                "title": "Krea 2 Medium",
+                "inputTokenLimit": 4000,
+                "outputTokenLimit": 4000,
+                "supportsImageGeneration": true
+            },
+            {
+                "name": "krea-2/large",
+                "title": "Krea 2 Large",
+                "inputTokenLimit": 4000,
+                "outputTokenLimit": 4000,
+                "supportsImageGeneration": true
+            }
+        ];
+    }
+
+    /**
+     * @description Initializes the prototype slots for the class.
+     * @category Initialization
+     */
+    initPrototypeSlots () {
+
+        /**
+         * @member {SvKreaImagePrompts} imagesPrompts
+         * @category Image Generation
+         */
+        {
+            const slot = this.newSlot("imagesPrompts", null);
+            slot.setFinalInitProto(SvKreaImagePrompts);
+            slot.setIsSubnode(true);
+            slot.setShouldStoreSlot(true);
+        }
+    }
+
+    initPrototype () {
+        this.setShouldStore(true);
+        this.setShouldStoreSubnodes(false);
+    }
+
+    /**
+     * @description Performs final initialization steps for the instance.
+     * @category Initialization
+     */
+    finalInit () {
+        super.finalInit();
+        this.setTitle(this.svType().before("Service"));
+    }
+
+    /**
+     * @description Validates the API key.
+     * @param {string} s - The API key to validate.
+     * @returns {boolean} True if the key is valid, false otherwise.
+     * @category Authentication
+     */
+    validateKey (s) {
+        return s.length > 20;
+    }
+
+}.initThisClass());

--- a/source/library/services/Krea/Text to Image/SvKreaImageGeneration.js
+++ b/source/library/services/Krea/Text to Image/SvKreaImageGeneration.js
@@ -1,0 +1,508 @@
+/**
+ * @module library.services.Krea.Text_to_Image
+ */
+
+/**
+ * @class SvKreaImageGeneration
+ * @extends SvSummaryNode
+ * @classdesc A submitted Krea job, polled until it completes.
+ *
+ * Krea's job lifecycle (GET /jobs/{id}) reports one of:
+ *   backlogged | queued | scheduled | processing | sampling
+ *   intermediate-complete | completed | failed | cancelled
+ *
+ * Polling goes through the proxy like every other request. The status endpoint is
+ * registered as FREE on the backend service, so a long poll loop cannot multiply
+ * the generation's charge.
+ *
+ * Every terminal path MUST settle completionPromise — a status that stops the
+ * poll loop without settling would hang the awaiting generate() chain forever
+ * and leave the UI shimmering with no error. (That exact bug was fixed three
+ * separate times in the ImaginePro equivalent; the shape is preserved here.)
+ */
+"use strict";
+
+(class SvKreaImageGeneration extends SvSummaryNode {
+
+    initPrototypeSlots () {
+
+        /**
+         * @member {string} promptNote
+         * @description The prompt this job was submitted with, for the record.
+         * @category Status
+         */
+        {
+            const slot = this.newSlot("promptNote", null);
+            slot.setShouldStoreSlot(true);
+            slot.setSyncsToView(true);
+            slot.setSlotType("String");
+            slot.setIsSubnodeField(true);
+            slot.setCanInspect(true);
+            slot.setCanEditInspection(false);
+        }
+
+        /**
+         * @member {string} jobId
+         * @description The Krea job id being polled.
+         * @category Status
+         */
+        {
+            const slot = this.newSlot("jobId", "");
+            slot.setShouldStoreSlot(true);
+            slot.setSyncsToView(true);
+            slot.setSlotType("String");
+            slot.setIsSubnodeField(true);
+            slot.setCanInspect(true);
+            slot.setCanEditInspection(false);
+        }
+
+        /**
+         * @member {string} status
+         * @category Status
+         */
+        {
+            const slot = this.newSlot("status", "pending");
+            slot.setShouldStoreSlot(true);
+            slot.setSyncsToView(true);
+            slot.setSlotType("String");
+            slot.setIsSubnodeField(true);
+            slot.setCanInspect(true);
+            slot.setCanEditInspection(false);
+        }
+
+        /**
+         * @member {Error} error
+         * @category Status
+         */
+        {
+            const slot = this.newSlot("error", null);
+            slot.setAllowsNullValue(true);
+            slot.setShouldStoreSlot(true);
+            slot.setSyncsToView(true);
+            slot.setSlotType("Error");
+            slot.setCanInspect(true);
+            slot.setCanEditInspection(false);
+        }
+
+        /**
+         * @member {SvFilesToDownload} images
+         * @description The result images, fetched by URL.
+         * @category Output
+         */
+        {
+            // Proto named as a STRING so resolution is deferred: this class lives
+            // outside the directory that defines SvFilesToDownload, and a direct
+            // class reference here would make correctness depend on _imports.json
+            // ordering across service directories.
+            const slot = this.newSlot("images", null);
+            slot.setFinalInitProto("SvFilesToDownload");
+            slot.setShouldStoreSlot(true);
+            slot.setIsSubnode(true);
+            slot.setSlotType("SvFilesToDownload");
+            slot.setCanInspect(true);
+            slot.setCanEditInspection(false);
+        }
+
+        /**
+         * @member {Object} delegate
+         * @category Delegation
+         */
+        {
+            const slot = this.newSlot("delegate", null);
+            slot.setShouldStoreSlot(true);
+            slot.setSlotType("Object");
+            slot.setCanInspect(true);
+            slot.setIsInCloudJson(false); // runtime ref; would be circular
+        }
+
+        /**
+         * @member {number} pollInterval
+         * @category Configuration
+         */
+        {
+            const slot = this.newSlot("pollInterval", 2000);
+            slot.setSlotType("Number");
+            slot.setShouldStoreSlot(true);
+            slot.setCanInspect(true);
+        }
+
+        /**
+         * @member {number} initialPollDelay
+         * @description Delay before the first poll. Krea creates a durable job
+         * before responding, so unlike the ImaginePro path this needs no
+         * registration grace period — just enough to avoid a pointless immediate
+         * round trip.
+         * @category Configuration
+         */
+        {
+            const slot = this.newSlot("initialPollDelay", 1000);
+            slot.setSlotType("Number");
+            slot.setShouldStoreSlot(true);
+            slot.setCanInspect(true);
+        }
+
+        /**
+         * @member {number} maxPollAttempts
+         * @description 450 x 2s ≈ 15 minutes.
+         *
+         * Sized from a measured run, not a guess: a plain generation completed
+         * in ~12s, but the first generation WITH a trained style took 163s —
+         * loading the style dominates. 5 minutes left too little headroom for a
+         * busy queue, and exhausting the budget fails a generation that was
+         * still progressing. Polls are free (the job endpoint is registered at
+         * zero cost), so a generous ceiling costs nothing but patience.
+         * @category Configuration
+         */
+        {
+            const slot = this.newSlot("maxPollAttempts", 450);
+            slot.setSlotType("Number");
+            slot.setShouldStoreSlot(true);
+            slot.setCanInspect(true);
+        }
+
+        /**
+         * @member {number} pollAttempts
+         * @category Status
+         */
+        {
+            const slot = this.newSlot("pollAttempts", 0);
+            slot.setSlotType("Number");
+            slot.setShouldStoreSlot(true);
+            slot.setCanInspect(true);
+        }
+
+        /**
+         * @member {Object} pollTimeoutId
+         * @category Internal
+         */
+        {
+            const slot = this.newSlot("pollTimeoutId", null);
+            slot.setAllowsNullValue(true);
+            slot.setSlotType("Object");
+            slot.setCanInspect(true);
+        }
+
+        /**
+         * @member {boolean} didReportIntermediate
+         * @description Guard so the intermediate-preview delegate call fires at
+         * most once per job.
+         * @category Status
+         */
+        {
+            const slot = this.newSlot("didReportIntermediate", false);
+            slot.setSlotType("Boolean");
+            slot.setShouldStoreSlot(false);
+        }
+
+        {
+            const slot = this.newSlot("completionPromise", null);
+            slot.setAllowsNullValue(true);
+            slot.setSlotType("Promise");
+            slot.setShouldStoreSlot(false);
+            slot.setSyncsToView(true);
+        }
+
+        this.setShouldStore(true);
+        this.setShouldStoreSubnodes(false);
+        this.setCanDelete(true);
+    }
+
+    finalInit () {
+        super.finalInit();
+        // Re-establish delegate relationships after cloud deserialization.
+        this.images().subnodes().forEach(image => {
+            image.setDelegate(this);
+        });
+    }
+
+    title () {
+        return `Job ${this.jobId().slice(0, 8)}`;
+    }
+
+    subtitle () {
+        return this.status();
+    }
+
+    service () {
+        return SvKreaService.shared();
+    }
+
+    // --- polling ---
+
+    /**
+     * @description Starts polling and resolves when the job reaches a terminal
+     * state.
+     * @returns {Promise}
+     * @category Process
+     */
+    async asyncStartPolling () {
+        this.setCompletionPromise(Promise.clone());
+        this.setPollAttempts(0);
+        this.setDidReportIntermediate(false);
+
+        this.shareProgress("waiting on image results...");
+        this.setStatus("preparing to poll for job status...");
+        this.sendDelegateMessage("onImageGenerationStart", [this]);
+
+        const timeoutId = setTimeout(() => {
+            this.setStatus("polling for job status...");
+            this.pollJobStatus();
+        }, this.initialPollDelay());
+        this.setPollTimeoutId(timeoutId);
+
+        return this.completionPromise();
+    }
+
+    stopPolling () {
+        if (this.pollTimeoutId()) {
+            clearTimeout(this.pollTimeoutId());
+            this.setPollTimeoutId(null);
+        }
+    }
+
+    /**
+     * @description The job status URL for this job.
+     * @returns {string}
+     * @category Process
+     */
+    jobStatusEndpoint () {
+        return SvKreaService.endpointBase() + "jobs/" + this.jobId();
+    }
+
+    /**
+     * @description Polls once, then either finishes or schedules the next poll.
+     * @category Process
+     */
+    async pollJobStatus () {
+        try {
+            const apiKey = await this.service().apiKeyOrUserAuthToken();
+            const proxyEndpoint = SvProxyServers.shared().defaultServer().proxyUrlForUrl(this.jobStatusEndpoint());
+
+            const request = SvXhrRequest.clone();
+            request.setUrl(proxyEndpoint);
+            request.setMethod("GET");
+            // No Content-Type on a GET: Firebase returns 400 for a GET that
+            // declares a body content type.
+            request.setHeaders({
+                "Authorization": `Bearer ${apiKey}`
+            });
+
+            await request.asyncSend();
+
+            if (request.isSuccess()) {
+                this.handlePollResponse(JSON.parse(request.responseText()));
+                return;
+            }
+
+            console.error(this.logPrefix() + " Krea poll request failed:", request.description());
+
+            // A 404 means this job id will never resolve — stop rather than
+            // burning the full attempt budget on a job that does not exist.
+            if (request.status() === 404) {
+                this.failWithError(new Error("Krea job not found (" + this.jobId() + ") - stopping polling"));
+                return;
+            }
+
+            // Any other failure may be transient; keep polling.
+            this.schedulePoll();
+        } catch (error) {
+            this.shareProgress("error polling for image results...");
+            console.error(this.logPrefix() + " poll error:", error);
+            this.schedulePoll();
+        }
+    }
+
+    /**
+     * @description Routes a job status payload to the matching terminal or
+     * continuation path. An unrecognized status keeps polling: a new Krea status
+     * string should slow us down, not fail a job that is actually progressing
+     * (the attempt budget still bounds it).
+     * @param {Object} response - The parsed job payload.
+     * @category Process
+     */
+    async handlePollResponse (response) {
+        const status = response.status;
+
+        if (status === "completed") {
+            this.handlePollDone(response);
+            return;
+        }
+
+        if (status === "failed" || status === "cancelled") {
+            this.handlePollError(response);
+            return;
+        }
+
+        if (status === "intermediate-complete") {
+            this.handlePollIntermediate(response);
+            return;
+        }
+
+        if (!["backlogged", "queued", "scheduled", "processing", "sampling"].includes(status)) {
+            console.warn(this.logPrefix() + " unknown Krea job status:", status);
+        }
+        this.setStatus(`${status}... (attempt ${this.pollAttempts() + 1}/${this.maxPollAttempts()})`);
+        this.schedulePoll();
+    }
+
+    /**
+     * @description Krea can publish a partial result before finishing. Surfacing
+     * it lets the UI show something in the reserved frame early. Best effort: if
+     * no urls are attached, this is just another pending tick.
+     * @param {Object} response - The parsed job payload.
+     * @category Process
+     */
+    async handlePollIntermediate (response) {
+        this.setStatus("intermediate result available...");
+        const imageUrls = this.imageUrlsFromResult(response.result);
+
+        if (imageUrls.length > 0 && !this.didReportIntermediate()) {
+            this.setDidReportIntermediate(true);
+            try {
+                await this.downloadImageUrls(imageUrls);
+                this.sendDelegateMessage("onImageGenerationIntermediate", [this]);
+            } catch (error) {
+                // A failed preview must never fail the job — the final result is
+                // still coming.
+                console.warn(this.logPrefix() + " intermediate preview failed:", error && error.message);
+            }
+        }
+        this.schedulePoll();
+    }
+
+    /**
+     * @description Normalizes Krea's `result.urls`, which is documented as
+     * either an array of url strings or an array of {type, url} objects. For the
+     * object form we keep only the actual model output, not the "preview"
+     * thumbnail.
+     * @param {Object} result - The job's result object.
+     * @returns {Array<string>} Image URLs, possibly empty.
+     * @category Results
+     */
+    imageUrlsFromResult (result) {
+        const urls = result ? result.urls : null;
+        if (!Array.isArray(urls)) {
+            return [];
+        }
+        const modelUrls = [];
+        const previewUrls = [];
+        urls.forEach(entry => {
+            if (typeof entry === "string") {
+                modelUrls.push(entry);
+            } else if (entry && typeof entry.url === "string") {
+                (entry.type === "preview" ? previewUrls : modelUrls).push(entry.url);
+            }
+        });
+        // Fall back to previews only if there is nothing else to show.
+        return modelUrls.length > 0 ? modelUrls : previewUrls;
+    }
+
+    async handlePollDone (response) {
+        this.shareProgress("got image results...");
+        this.setStatus("completed");
+        this.stopPolling();
+
+        try {
+            const imageUrls = this.imageUrlsFromResult(response.result);
+            if (imageUrls.length === 0) {
+                throw new Error("Krea job completed with no image urls");
+            }
+            // An intermediate may already have populated images; replace it so
+            // the final result is what consumers read.
+            this.images().removeAllSubnodes();
+            await this.downloadImageUrls(imageUrls);
+            this.completionPromise().callResolveFunc(this);
+        } catch (error) {
+            // handlePollDone is invoked WITHOUT await, so a throw here would
+            // otherwise skip the resolve above and leave completionPromise
+            // pending forever, hanging the awaiting generate() chain.
+            this.failWithError(Error.normalizeError(error));
+        }
+    }
+
+    async handlePollError (response) {
+        const errorInfo = response.error || {};
+        const message = errorInfo.message || errorInfo.code || response.status || "Unknown error";
+        const details = ["error: " + message];
+        if (response.status) {
+            details.push("status: " + response.status);
+        }
+        if (response.job_id) {
+            details.push("jobId: " + response.job_id);
+        }
+        console.error(this.logPrefix() + " Krea job failed:", response);
+        this.failWithError(new Error("Image generation failed (" + details.join(", ") + ")"));
+    }
+
+    /**
+     * @description The single terminal failure path: record the error, stop
+     * polling, settle the promise, notify the delegate. Everything that fails
+     * routes through here so no path can stop polling without settling.
+     * @param {Error} error - The failure.
+     * @category Process
+     */
+    failWithError (error) {
+        this.setStatus("failed");
+        this.setError(error);
+        this.stopPolling();
+        this.completionPromise().callRejectFunc(error);
+        this.sendDelegateMessage("onImageGenerationError", [this]);
+    }
+
+    /**
+     * @description Fetches the finished image bytes.
+     *
+     * VIA THE PROXY, NECESSARILY. Krea serves results from gen.krea.ai, which
+     * sends no Access-Control-Allow-Origin, so a direct browser read of the
+     * bytes fails with a CORS error. Krea offers no data-URI alternative (no
+     * sync_mode parameter, unlike fal). The proxy rewrites every response with
+     * `Access-Control-Allow-Origin: *`, so routing the download through it is
+     * what makes the bytes readable — the same job the MidJourney gateway used
+     * to do for us server-side.
+     *
+     * The proxy verifies a Firebase ID token, hence the bearer token; it strips
+     * that token before forwarding, and the media endpoint is registered
+     * `useBearerAuth: false`, so nothing credential-bearing reaches the CDN.
+     * The endpoint is also registered free, so re-fetching a generation's own
+     * output adds no cost.
+     *
+     * @param {Array<string>} imageUrls - Krea-hosted image URLs.
+     * @category Results
+     */
+    async downloadImageUrls (imageUrls) {
+        const authToken = await this.service().apiKeyOrUserAuthToken();
+        const promises = imageUrls.map(async (imageUrl, index) => {
+            const image = this.images().add();
+            image.setTitle(`image ${index + 1}`);
+            image.setUrl(SvProxyServers.shared().defaultServer().proxyUrlForUrl(imageUrl));
+            image.setBearerToken(authToken);
+            image.setDelegate(this);
+            return image.fetch();
+        });
+        await Promise.all(promises);
+    }
+
+    schedulePoll () {
+        this.setPollAttempts(this.pollAttempts() + 1);
+
+        if (this.pollAttempts() >= this.maxPollAttempts()) {
+            this.setStatus("timeout");
+            this.failWithError(new Error("Krea job timed out after " + this.maxPollAttempts() + " attempts"));
+            return;
+        }
+
+        const timeoutId = setTimeout(() => this.pollJobStatus(), this.pollInterval());
+        this.setPollTimeoutId(timeoutId);
+    }
+
+    shutdown () {
+        this.stopPolling();
+        this.images().subnodes().forEach(image => image.shutdown());
+        return this;
+    }
+
+    didUpdateSlotStatus (oldValue, newValue) {
+        this.shareProgress(newValue);
+    }
+
+}.initThisClass());

--- a/source/library/services/Krea/Text to Image/SvKreaImageGenerations.js
+++ b/source/library/services/Krea/Text to Image/SvKreaImageGenerations.js
@@ -1,0 +1,37 @@
+/**
+ * @module library.services.Krea.Text_to_Image
+ */
+
+/**
+ * @class SvKreaImageGenerations
+ * @extends SvSummaryNode
+ * @classdesc A collection of Krea image generation jobs.
+ */
+"use strict";
+
+(class SvKreaImageGenerations extends SvSummaryNode {
+
+    /**
+     * @description Initializes the prototype.
+     * @category Initialization
+     */
+    initPrototype () {
+        this.setShouldStore(true);
+        this.setShouldStoreSubnodes(true);
+        this.setCanDelete(true);
+        this.setSubnodeClasses([SvKreaImageGeneration]);
+        this.setNodeCanAddSubnode(false);
+        this.setNodeCanReorderSubnodes(false);
+        this.setNodeSubtitleIsChildrenSummary(true);
+    }
+
+    /**
+     * @description Performs final initialization.
+     * @category Initialization
+     */
+    finalInit () {
+        super.finalInit();
+        this.setTitle("generations");
+    }
+
+}.initThisClass());

--- a/source/library/services/Krea/Text to Image/SvKreaImagePrompt.js
+++ b/source/library/services/Krea/Text to Image/SvKreaImagePrompt.js
@@ -1,0 +1,979 @@
+"use strict";
+
+/**
+ * @module library.services.Krea.Text_to_Image
+ */
+
+/**
+ * @class SvKreaImagePrompt
+ * @extends SvSummaryNode
+ * @classdesc Represents a Krea 2 image generation request.
+ *
+ * Krea 2's distinguishing feature, and the reason this class exists, is that a
+ * single request carries BOTH:
+ *   - `styles`                 — our custom trained style (LoRA) by id
+ *   - `image_style_references` — up to 10 reference images
+ * so a scene can hold a trained art look AND per-subject visual continuity.
+ *
+ * BILLING (see Servers/Firebase/functions/src/services/KreaService.js): Krea
+ * charges a flat price per request chosen by a tier — text-to-image, style
+ * references, or moodboards — and one request yields exactly one image (there is
+ * no num_images parameter). A `styles` entry does NOT raise the tier, so running
+ * our own trained style is free; attaching reference images does raise it.
+ *
+ * This class implements the duck-typed interface UoImageMessage calls on an
+ * image prompt: setPrompt/setAspectRatio/aspectRatio/extraImagesNode/generate/
+ * error/status/resultImageNode/asyncFirstResultImageNode/generations/shutdown.
+ * It deliberately has NO setVersion — UoImageMessage guards on that to detect
+ * Midjourney-only prompts.
+ */
+
+(class SvKreaImagePrompt extends SvSummaryNode {
+
+    static initClass () {
+        super.initClass();
+
+        // Aspect ratios Krea accepts, as [label, value] with the numeric ratio
+        // derived rather than restated (one source of truth for coercion).
+        this.newClassSlot("supportedAspectRatios", ["1:1", "4:3", "3:2", "16:9", "2.35:1", "4:5", "2:3", "9:16"]);
+    }
+
+    initPrototypeSlots () {
+
+        /**
+         * @member {string} prompt
+         * @description The prompt text for image generation.
+         * @category Input
+         */
+        {
+            const slot = this.newSlot("prompt", "");
+            slot.setInspectorPath("");
+            slot.setAllowsNullValue(false);
+            slot.setShouldStoreSlot(true);
+            slot.setSyncsToView(true);
+            slot.setDuplicateOp("duplicate");
+            slot.setSlotType("String");
+            slot.setIsSubnodeField(true);
+        }
+
+        /**
+         * @member {string} promptSuffix
+         * @description Extra text appended to the prompt.
+         * @category Configuration
+         */
+        {
+            const slot = this.newSlot("promptSuffix", "");
+            slot.setSlotType("String");
+            slot.setAllowsNullValue(false);
+            slot.setLabel("Prompt Suffix");
+            slot.setIsSubnodeField(true);
+            slot.setShouldStoreSlot(true);
+            slot.setSyncsToView(true);
+            slot.setDuplicateOp("duplicate");
+            slot.setCanEditInspection(true);
+            slot.setDescription("Additional text appended to the prompt");
+        }
+
+        /**
+         * @member {string} fullPrompt
+         * @description The composed prompt actually sent, kept for inspection.
+         * @category Input
+         */
+        {
+            const slot = this.newSlot("fullPrompt", "");
+            slot.setSlotType("String");
+            slot.setLabel("Full Prompt");
+            slot.setIsSubnodeField(true);
+            slot.setShouldStoreSlot(true);
+            slot.setSyncsToView(true);
+            slot.setCanEditInspection(false);
+        }
+
+        // --- settings ---
+
+        /**
+         * @member {string} model
+         * @description Which Krea 2 tier to generate with. Selectable in the
+         * inspector so tiers can be compared on real generations; the labels
+         * carry the text-to-image price so the choice is informed. Prices rise
+         * by one step when reference images are attached.
+         * @category Configuration
+         */
+        {
+            const validItems = [
+                { value: "krea-2/medium-turbo", label: "Krea 2 Medium Turbo ($0.015)" },
+                { value: "krea-2/medium", label: "Krea 2 Medium ($0.03)" },
+                { value: "krea-2/large", label: "Krea 2 Large ($0.06)" }
+            ];
+            // Default to medium-turbo: cheapest tier ($0.015 text-to-image,
+            // $0.0175 with reference images) and fast, which is what we want
+            // while iterating. NOTE: a style trained with Krea's `k2` base is
+            // documented against Krea 2 MEDIUM; whether such a style also
+            // applies to this distilled turbo checkpoint is unverified. Revisit
+            // this default once a trained style exists.
+            const slot = this.newSlot("model", "krea-2/medium-turbo");
+            slot.setInspectorPath("Settings");
+            slot.setLabel("Model");
+            slot.setShouldStoreSlot(true);
+            slot.setSyncsToView(true);
+            slot.setDuplicateOp("duplicate");
+            slot.setSlotType("String");
+            slot.setValidItems(validItems);
+            slot.setIsSubnodeField(true);
+            slot.setSummaryFormat("key: value");
+        }
+
+        /**
+         * @member {string} aspectRatio
+         * @description Aspect ratio of the generated image. Krea accepts a fixed
+         * enum, so setAspectRatio() coerces an arbitrary request to the nearest
+         * supported value (see coercedAspectRatio) and this slot always holds a
+         * value Krea will accept.
+         * @category Configuration
+         */
+        {
+            const validItems = [
+                { value: "1:1", label: "1:1" },
+                { value: "4:3", label: "4:3" },
+                { value: "3:2", label: "3:2" },
+                { value: "16:9", label: "16:9" },
+                { value: "2.35:1", label: "2.35:1" },
+                { value: "4:5", label: "4:5" },
+                { value: "2:3", label: "2:3" },
+                { value: "9:16", label: "9:16" }
+            ];
+            const slot = this.newSlot("aspectRatio", "3:2");
+            slot.setInspectorPath("Settings");
+            slot.setLabel("Aspect Ratio");
+            slot.setShouldStoreSlot(true);
+            slot.setSyncsToView(true);
+            slot.setDuplicateOp("duplicate");
+            slot.setSlotType("String");
+            slot.setValidItems(validItems);
+            // PERMISSIVE ON PURPOSE. Callers set ratios Krea doesn't offer (the
+            // app's standard scene ratio is 5:3), and didUpdateSlotAspectRatio()
+            // coerces them to the nearest supported value. Without this flag the
+            // slot's own validation would reject 5:3 and silently substitute the
+            // slot's initValue ("1:1") BEFORE the coercion hook ever sees it —
+            // a wrong-shaped image, not merely a warning.
+            slot.setValidValuesArePermissive(true);
+            slot.setIsSubnodeField(true);
+            slot.setSummaryFormat("key: value");
+        }
+
+        /**
+         * @member {string} resolution
+         * @description Resolution scale. Krea currently documents only "1K".
+         * @category Configuration
+         */
+        {
+            const slot = this.newSlot("resolution", "1K");
+            slot.setInspectorPath("Settings");
+            slot.setLabel("Resolution");
+            slot.setShouldStoreSlot(true);
+            slot.setSyncsToView(true);
+            slot.setSlotType("String");
+            slot.setValidValues(["1K"]);
+            slot.setValidValuesArePermissive(true);
+            slot.setIsSubnodeField(true);
+            slot.setSummaryFormat("key: value");
+        }
+
+        /**
+         * @member {string} creativity
+         * @description Prompt-expansion mode. "raw" disables expansion, which is
+         * what we want when the prompt is already composed by the GM — an LLM
+         * rewriting it would fight our own prompt engineering.
+         * @category Configuration
+         */
+        {
+            const validItems = [
+                { value: "raw", label: "raw (no prompt expansion)" },
+                { value: "low", label: "low (Krea default)" },
+                { value: "medium", label: "medium" },
+                { value: "high", label: "high" }
+            ];
+            const slot = this.newSlot("creativity", "raw");
+            slot.setInspectorPath("Settings");
+            slot.setLabel("Creativity");
+            slot.setShouldStoreSlot(true);
+            slot.setSyncsToView(true);
+            slot.setDuplicateOp("duplicate");
+            slot.setSlotType("String");
+            slot.setValidItems(validItems);
+            slot.setIsSubnodeField(true);
+            slot.setSummaryFormat("key: value");
+        }
+
+        /**
+         * @member {string} styleId
+         * @description Id of a Krea trained style (LoRA) to apply. Empty means
+         * send no `styles` entry at all. Trained styles are private to the API
+         * key that created them, so this id is useless to a third party.
+         * @category Configuration
+         */
+        {
+            const slot = this.newSlot("styleId", "");
+            slot.setInspectorPath("Settings");
+            slot.setLabel("Style Id");
+            slot.setAllowsNullValue(false);
+            slot.setShouldStoreSlot(true);
+            slot.setSyncsToView(true);
+            slot.setDuplicateOp("duplicate");
+            slot.setSlotType("String");
+            slot.setIsSubnodeField(true);
+            slot.setCanEditInspection(true);
+            slot.setDescription("Krea trained style (LoRA) id. Empty = no style. Costs nothing extra.");
+            slot.setSummaryFormat("key: value");
+        }
+
+        /**
+         * @member {number} styleStrength
+         * @description How strongly the trained style applies (-2..2, 1 = full).
+         * @category Configuration
+         */
+        {
+            const validItems = [
+                { value: 0, label: "0 (No influence)" },
+                { value: 0.25, label: "0.25" },
+                { value: 0.5, label: "0.5" },
+                { value: 0.75, label: "0.75" },
+                { value: 1, label: "1 (Default)" },
+                { value: 1.25, label: "1.25" },
+                { value: 1.5, label: "1.5" },
+                { value: 2, label: "2 (Maximum)" }
+            ];
+            // 0.8 is Krea's own recommended starting point: their guidance puts
+            // 0.95-1.0 at "maximum style adherence, may reduce prompt
+            // responsiveness", which fights the detailed scene descriptions we
+            // send. 0.8-0.9 is "strong style application, recommended".
+            const slot = this.newSlot("styleStrength", 0.8);
+            slot.setSlotType("Number");
+            slot.setInspectorPath("Settings");
+            slot.setLabel("Style Strength");
+            slot.setShouldStoreSlot(true);
+            slot.setSyncsToView(true);
+            slot.setDuplicateOp("duplicate");
+            slot.setValidItems(validItems);
+            slot.setValidValuesArePermissive(true);
+            slot.setIsSubnodeField(true);
+            slot.setSummaryFormat("key: value");
+        }
+
+        /**
+         * @member {SvImagesNode} extraImagesNode
+         * @description Reference images, sent as `image_style_references`. Krea
+         * accepts up to 10; see referenceImageLimit(). Attaching any of these
+         * moves the request to the more expensive style-references tier.
+         * @category Configuration
+         */
+        {
+            const slot = this.newSlot("extraImagesNode", null);
+            slot.setInspectorPath("Settings");
+            slot.setFinalInitProto("SvImagesNode");
+            slot.setLabel("Reference Images");
+            slot.setIsSubnodeField(true);
+            slot.setShouldStoreSlot(true);
+            slot.setSyncsToView(true);
+            slot.setCanEditInspection(true);
+            slot.setDescription("Krea calls these 'image style references' (max 10).");
+            slot.setSummaryFormat("key: value");
+        }
+
+        /**
+         * @member {number} referenceStrength
+         * @description How strongly each reference image influences the result
+         * (0..1, Krea's default 0.5). Applied to every reference.
+         * @category Configuration
+         */
+        {
+            const validItems = [
+                { value: 0, label: "0 (No influence)" },
+                { value: 0.25, label: "0.25" },
+                { value: 0.4, label: "0.4" },
+                { value: 0.5, label: "0.5 (Default)" },
+                { value: 0.6, label: "0.6" },
+                { value: 0.75, label: "0.75" },
+                { value: 1, label: "1 (Maximum)" }
+            ];
+            const slot = this.newSlot("referenceStrength", 0.5);
+            slot.setSlotType("Number");
+            slot.setInspectorPath("Settings");
+            slot.setLabel("Reference Strength");
+            slot.setShouldStoreSlot(true);
+            slot.setSyncsToView(true);
+            slot.setDuplicateOp("duplicate");
+            slot.setValidItems(validItems);
+            slot.setValidValuesArePermissive(true);
+            slot.setIsSubnodeField(true);
+            slot.setSummaryFormat("key: value");
+        }
+
+        /**
+         * @member {number} seed
+         * @description Random seed, for reproducible generations.
+         * @category Configuration
+         */
+        {
+            const slot = this.newSlot("seed", null);
+            slot.setAllowsNullValue(true);
+            slot.setSlotType("Number");
+            slot.setInspectorPath("Settings");
+            slot.setLabel("Seed");
+            slot.setShouldStoreSlot(true);
+            slot.setSyncsToView(true);
+            slot.setDuplicateOp("duplicate");
+            slot.setIsSubnodeField(true);
+            slot.setSummaryFormat("key: value");
+        }
+
+        /**
+         * @member {SvXhrRequest} xhrRequest
+         * @description The submit request, kept for debugging.
+         * @category Request
+         */
+        {
+            const slot = this.newSlot("xhrRequest", null);
+            slot.setShouldJsonArchive(true);
+            slot.setInspectorPath("");
+            slot.setLabel("xhr request");
+            slot.setShouldStoreSlot(true);
+            slot.setSyncsToView(true);
+            slot.setFinalInitProto(SvXhrRequest);
+            slot.setIsSubnodeField(true);
+            slot.setCanEditInspection(false);
+        }
+
+        // --- generation ---
+
+        /**
+         * @member {Error} error
+         * @category Status
+         */
+        {
+            const slot = this.newSlot("error", null);
+            slot.setAllowsNullValue(true);
+            slot.setInspectorPath("");
+            slot.setShouldStoreSlot(false);
+            slot.setSyncsToView(true);
+            slot.setDuplicateOp("duplicate");
+            slot.setSlotType("Error");
+            slot.setCanEditInspection(false);
+            slot.setSummaryFormat("key value");
+        }
+
+        /**
+         * @member {string} status
+         * @category Status
+         */
+        {
+            const slot = this.newSlot("status", "");
+            slot.setLabel("Status");
+            slot.setInspectorPath("");
+            slot.setShouldStoreSlot(true);
+            slot.setSyncsToView(true);
+            slot.setDuplicateOp("duplicate");
+            slot.setSlotType("String");
+            slot.setCanEditInspection(false);
+            slot.setSummaryFormat("key value");
+        }
+
+        /**
+         * @member {SvKreaImageGenerations} generations
+         * @description Submitted jobs, each polling for its own completion.
+         * @category Output
+         */
+        {
+            const slot = this.newSlot("generations", null);
+            slot.setFinalInitProto(SvKreaImageGenerations);
+            slot.setShouldStoreSlot(true);
+            slot.setIsSubnode(true);
+            slot.setSlotType("SvKreaImageGenerations");
+        }
+
+        /**
+         * @member {SvImageNode} resultImageNode
+         * @description The generated image. Transient: consumers copy the blob
+         * out (UoImageMessage hands it to its own imageNode), so persisting it
+         * would duplicate the bytes.
+         * @category Output
+         */
+        {
+            const slot = this.newSlot("resultImageNode", null);
+            slot.setSlotType("SvImageNode");
+            slot.setLabel("Result Image");
+            slot.setIsSubnodeField(true);
+            slot.setAllowsNullValue(true); // starts null, and clear() resets it to null
+            slot.setShouldStoreSlot(false);
+            slot.setSyncsToView(true);
+            slot.setFieldInspectorClassName("SvImageWellField");
+            slot.setCanEditInspection(false);
+        }
+
+        /**
+         * @member {Object} delegate
+         * @category Delegation
+         */
+        {
+            const slot = this.newSlot("delegate", null);
+            slot.setSlotType("Object");
+            slot.setShouldStoreSlot(true);
+        }
+
+        /**
+         * @member {Action} newSeedAction
+         * @category Action
+         */
+        {
+            const slot = this.newSlot("newSeedAction", null);
+            slot.setInspectorPath("");
+            slot.setLabel("New Seed");
+            slot.setSyncsToView(true);
+            slot.setDuplicateOp("duplicate");
+            slot.setSlotType("Action");
+            slot.setIsSubnodeField(true);
+            slot.setActionMethodName("newSeed");
+        }
+
+        /**
+         * @member {Action} generateAction
+         * @category Action
+         */
+        {
+            const slot = this.newSlot("generateAction", null);
+            slot.setInspectorPath("");
+            slot.setLabel("Generate");
+            slot.setSyncsToView(true);
+            slot.setDuplicateOp("duplicate");
+            slot.setSlotType("Action");
+            slot.setIsSubnodeField(true);
+            slot.setActionMethodName("generate");
+        }
+
+        /**
+         * @member {Action} clearAction
+         * @category Action
+         */
+        {
+            const slot = this.newSlot("clearAction", null);
+            slot.setInspectorPath("");
+            slot.setLabel("Clear");
+            slot.setSyncsToView(true);
+            slot.setDuplicateOp("duplicate");
+            slot.setSlotType("Action");
+            slot.setIsSubnodeField(true);
+            slot.setActionMethodName("clear");
+        }
+
+        {
+            const slot = this.newSlot("completionPromise", null);
+            slot.setSlotType("Promise");
+        }
+    }
+
+    initPrototype () {
+        this.setShouldStore(true);
+        this.setShouldStoreSubnodes(false);
+        this.setSubnodeClasses([]);
+        this.setNodeCanAddSubnode(false);
+        this.setCanDelete(true);
+        this.setNodeCanReorderSubnodes(false);
+    }
+
+    finalInit () {
+        super.finalInit();
+        this.setCanDelete(true);
+        this.extraImagesNode().setTitle("Reference Images");
+        if (this.seed() === null) {
+            this.pickRandomSeed();
+        }
+
+        // Re-establish delegate relationships after cloud deserialization
+        // (delegates are excluded from cloud JSON to avoid circular references).
+        this.generations().subnodes().forEach(gen => {
+            gen.setDelegate(this);
+        });
+    }
+
+    title () {
+        const p = this.prompt().clipWithEllipsis(15);
+        return p ? p : "Image Prompt";
+    }
+
+    subtitle () {
+        return this.status();
+    }
+
+    /**
+     * @description The Krea service singleton.
+     * @returns {SvKreaService}
+     * @category Service
+     */
+    service () {
+        return SvKreaService.shared();
+    }
+
+    imagePrompts () {
+        return this.parentNode();
+    }
+
+    appendStatus (status) {
+        this.setStatus(this.status() + "\n" + status);
+        this.shareProgress(status);
+        return this;
+    }
+
+    onDescendantProgress (descendant, status) {
+        this.appendStatus(status);
+    }
+
+    pickRandomSeed () {
+        this.setSeed(Number.randomUint32());
+    }
+
+    newSeed () {
+        this.pickRandomSeed();
+    }
+
+    // --- aspect ratio coercion ---
+
+    /**
+     * @description Parses an "w:h" ratio string into a number.
+     * @param {string} s - A ratio such as "16:9" or "2.35:1".
+     * @returns {number|null} The numeric ratio, or null if unparseable.
+     * @category Configuration
+     */
+    numericAspectRatio (s) {
+        const parts = String(s).split(":");
+        if (parts.length !== 2) {
+            return null;
+        }
+        const w = parseFloat(parts[0]);
+        const h = parseFloat(parts[1]);
+        if (!isFinite(w) || !isFinite(h) || w <= 0 || h <= 0) {
+            return null;
+        }
+        return w / h;
+    }
+
+    /**
+     * @description Maps an arbitrary aspect ratio to the nearest one Krea
+     * accepts. Distance is measured on the LOG of the ratio, which is the
+     * scale-invariant comparison for ratios (so 3:2 vs 16:9 is judged by
+     * proportional, not absolute, difference). Krea natively offers 3:2, which
+     * is what the app asks for, so the common path coerces nothing; a request
+     * for e.g. 5:3 would resolve to 16:9.
+     * @param {string} requested - The desired ratio.
+     * @param {string} fallback - Ratio to use when `requested` is unparseable.
+     *   Callers pass the value being replaced; it is itself validated, so a
+     *   nonsense fallback can't slip through either.
+     * @returns {string} A ratio from supportedAspectRatios().
+     * @category Configuration
+     */
+    coercedAspectRatio (requested, fallback) {
+        const supported = this.thisClass().supportedAspectRatios();
+        if (supported.includes(requested)) {
+            return requested;
+        }
+        const target = this.numericAspectRatio(requested);
+        if (target === null) {
+            // Unparseable. Do NOT read the slot back here: the generated setter
+            // has already stored `requested`, so the slot would hand us the bad
+            // value and we would "coerce" it to itself — leaving a ratio Krea
+            // rejects. Fall back to the outgoing value, or the default.
+            // Last resort when the outgoing value is unusable too. Keep this in
+            // sync with the aspectRatio slot's default.
+            return supported.includes(fallback) ? fallback : "3:2";
+        }
+        let best = supported.first();
+        let bestDistance = Infinity;
+        supported.forEach(candidate => {
+            const value = this.numericAspectRatio(candidate);
+            const distance = Math.abs(Math.log(value) - Math.log(target));
+            if (distance < bestDistance) {
+                bestDistance = distance;
+                best = candidate;
+            }
+        });
+        return best;
+    }
+
+    /**
+     * @description Coerces an out-of-enum aspect ratio to the nearest supported
+     * one, right after it is set.
+     *
+     * WHY A didUpdateSlot HOOK AND NOT A setAspectRatio() OVERRIDE: slots
+     * generate their own accessors and install them onto the prototype AFTER the
+     * class body is evaluated, so a class-body method named setAspectRatio()
+     * would be silently overwritten by the generated setter and never run. The
+     * update hook is the supported interception point.
+     *
+     * Terminates in one extra write: the re-set value is in the supported list,
+     * so the second pass through this hook is a no-op.
+     * @param {string} oldValue - The previous ratio.
+     * @param {string} newValue - The ratio just assigned.
+     * @category Configuration
+     */
+    didUpdateSlotAspectRatio (oldValue, newValue) {
+        const coerced = this.coercedAspectRatio(newValue, oldValue);
+        if (coerced !== newValue) {
+            console.log(this.logPrefix(), "coerced aspect ratio", newValue, "->", coerced);
+            this.setAspectRatio(coerced);
+        }
+    }
+
+    // --- request composition ---
+
+    /**
+     * @description Krea accepts at most 10 style references.
+     * @returns {number}
+     * @category Configuration
+     */
+    referenceImageLimit () {
+        return 10;
+    }
+
+    trimmedPromptSuffix () {
+        return this.promptSuffix().trim();
+    }
+
+    composeFullPrompt () {
+        const parts = [this.prompt().trim(), this.trimmedPromptSuffix()];
+        const fullPrompt = parts.filter(s => s.length > 0).join(" ");
+        this.setFullPrompt(fullPrompt);
+        return fullPrompt;
+    }
+
+    /**
+     * @description Validates that a URL is publicly reachable by Krea's servers.
+     * @param {string} url - The URL to check.
+     * @param {string} context - What the URL is for, for the error message.
+     * @category Validation
+     */
+    assertPublicUrl (url, context) {
+        if (!url) {
+            return;
+        }
+        let parsed = null;
+        try {
+            parsed = new URL(url);
+        } catch {
+            throw new Error(context + " is not a valid URL: " + url);
+        }
+        const hostname = parsed.hostname;
+        const isLocal = hostname === "localhost"
+            || hostname === "127.0.0.1"
+            || hostname === "0.0.0.0"
+            || hostname.startsWith("192.168.")
+            || hostname.startsWith("10.");
+        if (isLocal) {
+            throw new Error(context + " URL is not publicly accessible: " + url);
+        }
+    }
+
+    /**
+     * @description Builds the `image_style_references` array from the reference
+     * images, resolving each to a public URL.
+     * @returns {Promise<Array<Object>>}
+     * @category Request
+     */
+    async asyncComposeStyleReferences () {
+        const nodes = this.extraImagesNode().subnodes().slice(0, this.referenceImageLimit());
+        const strength = this.referenceStrength();
+        return await nodes.promiseParallelMap(async svImageNode => {
+            const url = await svImageNode.asyncPublicUrl();
+            this.assertPublicUrl(url, "Reference image");
+            return { url: url, strength: strength };
+        });
+    }
+
+    /**
+     * @description Builds the `styles` array from the configured trained style.
+     * Empty when no style id is set.
+     * @returns {Array<Object>}
+     * @category Request
+     */
+    composeStyles () {
+        const id = this.styleId().trim();
+        if (id.length === 0) {
+            return [];
+        }
+        return [{ id: id, strength: this.styleStrength() }];
+    }
+
+    /**
+     * @description Builds the full Krea request body. Feature arrays are omitted
+     * when empty rather than sent as [] — the backend's billing tier is derived
+     * from these fields, and an empty array must not read as "used".
+     * @returns {Promise<Object>}
+     * @category Request
+     */
+    async asyncComposeRequestBody () {
+        const body = {
+            prompt: this.composeFullPrompt(),
+            aspect_ratio: this.aspectRatio(),
+            resolution: this.resolution(),
+            creativity: this.creativity()
+        };
+
+        if (this.seed() !== null) {
+            body.seed = this.seed();
+        }
+
+        const styles = this.composeStyles();
+        if (styles.length > 0) {
+            body.styles = styles;
+        }
+
+        const references = await this.asyncComposeStyleReferences();
+        if (references.length > 0) {
+            body.image_style_references = references;
+        }
+
+        return body;
+    }
+
+    /**
+     * @description The generation endpoint for the selected model.
+     * @returns {string}
+     * @category Request
+     */
+    generateEndpoint () {
+        return SvKreaService.endpointBase() + "generate/image/krea/" + this.model();
+    }
+
+    // --- generation ---
+
+    canGenerate () {
+        return this.prompt().length !== 0;
+    }
+
+    generateActionInfo () {
+        return {
+            isEnabled: this.canGenerate(),
+            isVisible: true
+        };
+    }
+
+    /**
+     * @description Runs a generation to completion.
+     * @category Action
+     */
+    async generate () {
+        await this.start();
+        this.onPromptEnd();
+    }
+
+    /**
+     * @description Submits the job and awaits its completion.
+     * @category Process
+     */
+    async start () {
+        performance.mark("krea-generation-start");
+
+        this.setCompletionPromise(Promise.clone());
+        this.setError(null);
+        this.setStatus("submitting job...");
+        this.notifyOwners("onImagePromptStart", [this]);
+
+        try {
+            const bodyJson = await this.asyncComposeRequestBody();
+            const jobId = await this.asyncSubmitJob(bodyJson);
+            await this.addGenerationForJobId(jobId, bodyJson.prompt);
+            await this.asyncCollectResultImage();
+        } catch (error) {
+            this.setError(error);
+            this.setStatus("Error: " + error.message);
+            throw error;
+        } finally {
+            performance.mark("krea-generation-end");
+            performance.measure("krea-generation", "krea-generation-start", "krea-generation-end");
+        }
+    }
+
+    /**
+     * @description POSTs the generation request through the proxy and returns
+     * the job id.
+     *
+     * IMPORTANT: always via the proxy — for accounting (usage is billed to the
+     * player), authentication (the Krea key stays server-side), and CORS.
+     * @param {Object} bodyJson - The composed request body.
+     * @returns {Promise<string>} The job id.
+     * @category Process
+     */
+    async asyncSubmitJob (bodyJson) {
+        const apiKey = await this.service().apiKeyOrUserAuthToken();
+        const proxyEndpoint = SvProxyServers.shared().defaultServer().proxyUrlForUrl(this.generateEndpoint());
+
+        const request = SvXhrRequest.clone();
+        request.setDelegate(this);
+        request.setUrl(proxyEndpoint);
+        request.setMethod("POST");
+        request.setHeaders({
+            "Authorization": `Bearer ${apiKey}`,
+            "Content-Type": "application/json"
+        });
+        request.setBody(JSON.stringify(bodyJson));
+        this.setXhrRequest(request);
+
+        await request.asyncSend();
+
+        if (request.hasError()) {
+            throw request.error();
+        }
+
+        const responseJson = this.parsedResponseJson(request);
+        const jobId = responseJson.job_id;
+        if (!jobId) {
+            throw new Error(this.logPrefix() + " no job_id returned from Krea");
+        }
+        return jobId;
+    }
+
+    /**
+     * @description Parses a JSON response, reporting the raw body on failure so
+     * an HTML error page doesn't surface as an opaque syntax error.
+     * @param {SvXhrRequest} request - The completed request.
+     * @returns {Object}
+     * @category Process
+     */
+    parsedResponseJson (request) {
+        try {
+            return JSON.parse(request.responseText());
+        } catch (error) {
+            throw new Error(this.logPrefix() + " (" + error.message + ") response is not valid JSON: " + request.responseText());
+        }
+    }
+
+    /**
+     * @description Adds a generation for the job and waits for it to finish.
+     * @param {string} jobId - The Krea job id.
+     * @param {string} fullPrompt - The prompt sent, for the record.
+     * @category Process
+     */
+    async addGenerationForJobId (jobId, fullPrompt) {
+        this.setStatus("job submitted, awaiting completion...");
+        const generation = this.generations().add();
+        generation.setPromptNote(fullPrompt);
+        generation.setJobId(jobId);
+        generation.setDelegate(this);
+        await generation.asyncStartPolling();
+    }
+
+    /**
+     * @description Fetches the finished image's bytes and publishes it on
+     * resultImageNode, which is what consumers read.
+     * @category Results
+     */
+    async asyncCollectResultImage () {
+        this.setStatus("fetching image...");
+        const node = await this.asyncFirstResultImageNode();
+        if (!node) {
+            throw new Error(this.logPrefix() + " generation completed with no image");
+        }
+        this.setResultImageNode(node);
+        this.setStatus("completed");
+    }
+
+    onPromptEnd () {
+        this.notifyOwners("onImagePromptEnd", [this]);
+    }
+
+    // --- results ---
+
+    allResultImages () {
+        return this.generations().subnodes().map(generation => generation.images().subnodes()).flat();
+    }
+
+    /**
+     * @description Fetches the file's bytes if needed and returns its image node.
+     *
+     * Deliberately sets NO referer. The Midjourney path sends one because its
+     * CDN wants it; for Krea it would be useless twice over — `Referer` is a
+     * browser-forbidden header that XHR silently drops, and were it not
+     * forbidden, adding a non-simple header would force a CORS preflight on a
+     * request that is already CORS-sensitive. The URL and auth are set up by
+     * SvKreaImageGeneration.downloadImageUrls().
+     *
+     * @param {SvFileToDownload} fileToDownload - The result file.
+     * @returns {Promise<SvImageNode>}
+     * @category Results
+     */
+    async asyncImageNodeForResultFile (fileToDownload) {
+        await fileToDownload.asyncFetchIfNeeded();
+        return fileToDownload.imageNode();
+    }
+
+    /**
+     * @description The first available result image, fetching bytes if needed.
+     * Used both for the final result and for the early preview hook.
+     * @returns {Promise<SvImageNode|null>}
+     * @category Results
+     */
+    async asyncFirstResultImageNode () {
+        const fileToDownload = this.allResultImages().first();
+        if (!fileToDownload) {
+            return null;
+        }
+        return await this.asyncImageNodeForResultFile(fileToDownload);
+    }
+
+    async asyncAllResultImageNodes () {
+        const imageNodes = [];
+        for (const fileToDownload of this.allResultImages()) {
+            imageNodes.push(await this.asyncImageNodeForResultFile(fileToDownload));
+        }
+        return imageNodes;
+    }
+
+    /**
+     * @description Data-URL fallback for consumers that don't use
+     * resultImageNode().
+     * @returns {Promise<string|null>}
+     * @category Results
+     */
+    async resultImageUrlData () {
+        const fileToDownload = this.allResultImages().last();
+        if (fileToDownload) {
+            return await fileToDownload.asyncDataUrl();
+        }
+        return null;
+    }
+
+    // --- SvXhrRequest delegate ---
+
+    onRequestProgress (request) {
+        this.setStatus(`uploading: ${request.contentByteCount()} bytes`);
+    }
+
+    // --- generation delegate ---
+
+    /**
+     * @description Best-effort early preview: Krea reports an
+     * `intermediate-complete` status, and when that arrives with image urls we
+     * surface the partial image so the reserved frame shows something before the
+     * final result. Absent intermediates, nothing fires and behavior is
+     * unchanged.
+     * @param {SvKreaImageGeneration} generation - The reporting generation.
+     * @category Progressive Loading
+     */
+    onImageGenerationIntermediate (generation) {
+        this.notifyOwners("onImagePromptFirstImages", [this]);
+    }
+
+    // --- lifecycle ---
+
+    shutdown (visited = new Set()) {
+        this.nodeShutdown(visited);
+        return this;
+    }
+
+    clear () {
+        this.setStatus("");
+        this.setError(null);
+        this.shutdown();
+        this.generations().removeAllSubnodes();
+        this.setResultImageNode(null);
+    }
+
+}.initThisClass());

--- a/source/library/services/Krea/Text to Image/SvKreaImagePrompts.js
+++ b/source/library/services/Krea/Text to Image/SvKreaImagePrompts.js
@@ -1,0 +1,32 @@
+/**
+ * @module library.services.Krea.Text_to_Image
+ */
+
+/**
+ * @class SvKreaImagePrompts
+ * @extends SvJsonArrayNode
+ * @classdesc A collection of Krea image prompts.
+ */
+"use strict";
+
+(class SvKreaImagePrompts extends SvJsonArrayNode {
+
+    /**
+     * @description Initializes the prototype.
+     * @category Initialization
+     */
+    initPrototype () {
+        this.setShouldStore(true);
+        this.setShouldStoreSubnodes(true);
+        this.setCanDelete(false);
+        this.setSubnodeClasses([SvKreaImagePrompt]);
+        this.setNodeCanReorderSubnodes(false);
+        this.setTitle("Image Prompts");
+    }
+
+    finalInit () {
+        super.finalInit();
+        this.initPrototype();
+    }
+
+}.initThisClass());

--- a/source/library/services/Krea/Text to Image/_imports.json
+++ b/source/library/services/Krea/Text to Image/_imports.json
@@ -1,0 +1,6 @@
+[
+  "SvKreaImageGeneration.js",
+  "SvKreaImageGenerations.js",
+  "SvKreaImagePrompt.js",
+  "SvKreaImagePrompts.js"
+]

--- a/source/library/services/Krea/_imports.json
+++ b/source/library/services/Krea/_imports.json
@@ -1,0 +1,4 @@
+[
+  "Text to Image/_imports.json",
+  "SvKreaService.js"
+]

--- a/source/library/services/SvServices.js
+++ b/source/library/services/SvServices.js
@@ -116,6 +116,18 @@
 
 
         /**
+         * @member {SvKreaService} kreaService
+         * @category AI Service
+         */
+        {
+            const slot = this.newSlot("kreaService", null);
+            slot.setShouldStoreSlot(true);
+            slot.setFinalInitProto(SvKreaService);
+            slot.setIsSubnodeField(true);
+        }
+
+
+        /**
          * @member {SvOpenAiService} openAiService
          * @category AI Service
          */

--- a/source/library/services/_imports.json
+++ b/source/library/services/_imports.json
@@ -8,6 +8,7 @@
     "Gemini/_imports.json",
     "Leonardo/_imports.json",
     "ImaginePro/_imports.json",
+    "Krea/_imports.json",
     "Xai/_imports.json",
     "YouTube/_imports.json",
     "Peer/_imports.json",


### PR DESCRIPTION
Adds `SvKreaService` and the prompt/generation pair for **Krea 2** image generation, mirroring the existing ImaginePro trio.

**Stacked on #41 — review that one first.** Base is `krea/file-download-bearer-token`, so this diff is Krea-only.

## Why Krea, and why direct

Krea 2 is the only image API we found that accepts a **custom trained style (LoRA)** *and* **reference images in the same request** — the combination a scene image needs to carry both a trained art look and per-subject visual continuity.

fal.ai hosts Krea 2 only as *split* endpoints, and the split is exactly the thing we need whole:

| fal endpoint | trained LoRA | reference images |
| --- | --- | --- |
| `fal-ai/krea-2/turbo/lora` | yes (3) | **no** |
| `fal-ai/krea-2/turbo/style` | **no** | yes (1–3, style only) |
| `krea/v2/*` (fal's proxy of Krea) | preset styles only | yes (10) |

Enumerated from fal's model API and per-endpoint OpenAPI schemas, so that's the full surface there — there is no Krea 2 edit endpoint on fal at all.

## Shape

`POST /generate/image/krea/{model}` → `{job_id}` → poll `GET /jobs/{id}` → fetch the result image. Same submit/poll shape as the Midjourney path.

## Three things worth a reviewer's attention

**1. No eval pass, and that's correct.** Krea's endpoints have no `num_images` parameter — one request is one image. There is no grid, so the Gemini evaluator would have nothing to select between; it would be one extra model call to "choose" the only candidate.

**2. Aspect ratio is coerced, via a slot hook rather than a setter.** Krea accepts a fixed enum and callers ask for ratios outside it (the app's scene default is `5:3` → `16:9`, nearest in log space). Two framework hazards shaped this, both deliberate:

- Coercion lives in `didUpdateSlotAspectRatio`, **not** a `setAspectRatio()` override — slot accessors are installed onto the prototype *after* the class body evaluates, so an override is silently clobbered and never runs.
- The slot is `setValidValuesArePermissive(true)`. Without it, `validatesOnSet` (default **true**) does not merely warn on an out-of-enum value — it substitutes the slot's `initValue`, so every scene would have quietly rendered **1:1**.

**3. Result images are fetched through the proxy, necessarily.** `gen.krea.ai` sends no `Access-Control-Allow-Origin` (verified: Cloudflare, no ACAO on HEAD or GET, with or without an `Origin` header), so a direct browser read of the bytes fails. Krea has no data-URI escape hatch either (no `sync_mode`, unlike fal). The proxy rewrites every response with `Access-Control-Allow-Origin: *`, which is what makes the bytes readable — the same job the Midjourney gateway did for us server-side. This is what needs the parent PR's `bearerToken`.

## Reliability invariant

Every terminal poll path settles `completionPromise`. A path that stops polling *without* settling hangs the awaiting `generate()` chain and shimmers the UI forever with no error — that exact bug was fixed three separate times in the ImaginePro equivalent, so the shape is preserved deliberately.

## Testing

App-side coverage lives in the consuming repo (85 headless checks over aspect coercion, request-body composition, Krea's polymorphic `result.urls`, and interface conformance). Not yet exercised against the live API — that needs a funded Krea API balance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)