### PR TITLE
Register GPT-6 Astra

### DIFF
--- a/source/library/services/OpenAI/SvOpenAiService.js
+++ b/source/library/services/OpenAI/SvOpenAiService.js
@@ -33,6 +33,15 @@
    */
     modelsJson () {
         return [
+            {
+                "name": "gpt-6-astra",
+                "title": "GPT-6 Astra",
+                // Keep the app's compaction budget at 200k (API context: 1.05M).
+                "inputTokenLimit": 200000,
+                "outputTokenLimit": 128000,
+                "supportsTemperature": false,
+                "supportsTopP": false
+            },
 
             {
                 "name": "gpt-5.2",


### PR DESCRIPTION
Registers GPT-6 Astra for application-specific assistant defaults. Disables unsupported temperature and top-p controls and uses a 200k application compaction budget.

Validation: model selection and sampling configuration tests plus production build in CloudNodes. This registry entry has already been deployed to production; no paid playtest was run.
