### PR TITLE
Carry document metadata through snapshots and listings

### DIFF
--- a/source/library/cloudfs/SvFsDocumentSession.js
+++ b/source/library/cloudfs/SvFsDocumentSession.js
@@ -76,6 +76,11 @@
             slot.setSlotType("Boolean");
         }
         {
+            const slot = this.newSlot("metadataProvider", null);
+            slot.setSlotType("Function");
+            slot.setComment("Optional synchronous cloudMetadata producer for snapshot saves");
+        }
+        {
             const slot = this.newSlot("onLeaseLost", null);
             slot.setSlotType("Function");
             slot.setComment("Called once when another writer steals our lease");
@@ -216,7 +221,7 @@
      * @param {*} content
      * @returns {Promise<{deletedDeltas:number, headSeq:number}>}
      */
-    async asyncWriteSnapshot (content) {
+    async asyncWriteSnapshot (content, metadata = undefined) {
         if (!this.isOpen()) {
             const e = new Error("session not open");
             e.code = "failed-precondition";
@@ -228,9 +233,13 @@
             e.svIsConflict = true;
             throw e;
         }
+        if (metadata === undefined) {
+            metadata = this.metadataProvider() ? this.metadataProvider()() : null;
+        }
         const result = await this.executeWithRetry(() => this.backend().coalesceDocument({
             nodeId: this.nodeId(),
-            newPool: content
+            newPool: content,
+            metadata
         }));
         // headSeq is reset by coalesce; reflect that in our local lease.
         const lease = this.currentLease() || {};

--- a/source/library/cloudfs/SvFsNode.js
+++ b/source/library/cloudfs/SvFsNode.js
@@ -78,6 +78,12 @@
             slot.setComment("server-set on create; locked against client updates after that");
         }
         {
+            const slot = this.newSlot("documentMetadata", null);
+            slot.setSlotType("Object");
+            slot.setAllowsNullValue(true);
+            slot.setComment("Snapshot summary envelope: schemaVersion, sourceHash, fields; null when missing or invalidated.");
+        }
+        {
             const slot = this.newSlot("rawData", null);
             slot.setSlotType("Object");
             slot.setComment("the original backend payload, for debugging / forward-compat fields");
@@ -114,6 +120,7 @@
     applyData (data) {
         if (!data) return this;
         this.setRawData(data);
+        this.setDocumentMetadata(data.documentMetadata || null);
         if ("id" in data) this.setId(data.id);
         if ("parentId" in data) this.setParentId(data.parentId);
         if ("sortKey" in data) this.setSortKey(data.sortKey);

--- a/source/library/node/json/SvSyncableJsonGroup.js
+++ b/source/library/node/json/SvSyncableJsonGroup.js
@@ -224,16 +224,17 @@
 
     /**
      * @description Returns metadata for cloud storage.
-     * Subclasses can override to include additional metadata.
-     * @returns {Object} Metadata object with title, subtitle, type, lastModified
+     * Subclasses override to include bounded JSON description fields. Keep
+     * this deterministic: storage associates the result with its snapshot.
+     * Do not include timestamps, private notes, full documents, or assets.
+     * @returns {Object} Metadata object with title, subtitle and type
      * @category Sync
      */
     cloudMetadata () {
         return {
             type: this.svType(),
             title: this.title ? this.title() : this.jsonId(),
-            subtitle: this.subtitle ? this.subtitle() : "",
-            lastModified: Date.now()
+            subtitle: this.subtitle ? this.subtitle() : ""
         };
     }
 

--- a/source/library/node/nodes/syncing/SvSyncCollectionSource.js
+++ b/source/library/node/nodes/syncing/SvSyncCollectionSource.js
@@ -213,6 +213,7 @@
             title: item.title ? item.title() : item.jsonId(),
             subtitle: item.subtitle ? item.subtitle() : "",
             thumbnailUrl: null,
+            ...(item.cloudMetadata ? item.cloudMetadata() : {}),
             lastModified: Date.now()
         };
 


### PR DESCRIPTION
Carries small document metadata projections through snapshot saves, cloud node listings, and collection manifests. Existing callers can omit metadata; content remains authoritative.

Validation: real-class campaign, character, manifest and listing projection checks pass in CloudNodes; 23 backend tests including metadata validation pass. No emulator or paid playtest was run.
