### PR TITLE
Wire the XHR retry mechanism to the error path, opt-in per request

### DIFF
--- a/source/library/services/AiServiceKit/Files/SvFileToDownload.js
+++ b/source/library/services/AiServiceKit/Files/SvFileToDownload.js
@@ -290,6 +290,15 @@
 
         request.setTimeoutPeriodInMs(120 * 1000);
 
+        // Opt in to SvXhrRequest's automatic retry (off by default). A transient
+        // 502 - from the image host, or from our own /proxy when its upstream
+        // socket dies - used to kill the whole generation, because the enclosing
+        // Promise.all over the download urls rejects on the first failure.
+        // Retrying is safe here and nowhere else on this path: this is a GET of
+        // finished, immutable bytes for a job that has already been billed, so
+        // repeating it cannot duplicate work or charge the player twice.
+        request.setMaxRetries(3);
+
         try {
             await request.asyncSend();
 

--- a/source/library/services/AiServiceKit/Requests/SvXhrRequest.js
+++ b/source/library/services/AiServiceKit/Requests/SvXhrRequest.js
@@ -18,6 +18,7 @@
  *   - isStreaming (default false)
  *   - requestId (default puuid)
  *   - retryDelaySeconds
+ *   - maxRetries (default 0 - automatic retry is opt-in, see the slot comment)
  *
  * Delegate protocol:
  *
@@ -140,15 +141,52 @@
             slot.setSummaryFormat("{key}:\n{value}");
         }
 
-        // max retries
+        // Automatic retry is OPT-IN: 0 means "never retry automatically", and
+        // setMaxRetries(n) turns it on for a request the caller knows is safe to
+        // repeat. Blanket retry is not safe here:
+        //   - SvAiRequest composes an SvXhrRequest and consumes it incrementally,
+        //     so a silent restart would re-deliver the prefix it already read.
+        //   - A non-idempotent POST (an image job submit) can be re-charged: our
+        //     proxy reports a 502 for a socket error that may fire AFTER the
+        //     upstream accepted the request and created a billable job.
+        // Changing the default from 3 to 0 takes NOTHING away, because the 3
+        // was inert: maxRetries was read in exactly one place
+        // (hasExceededMaxRetries), which was called in exactly one place
+        // (retryIfApplicable), which had no callers at all. No request has ever
+        // retried automatically. 0 is therefore the value that PRESERVES the
+        // old behavior; leaving it at 3 would have silently switched on three
+        // automatic retries for every XHR in the framework, streaming AI
+        // requests included.
+        //
+        // The manual "Retry Request" inspector action is a separate path and is
+        // unaffected: retryRequest() has never consulted maxRetries.
+        //
+        // This slot is not stored (setShouldStoreSlot(false) below), so changing
+        // the default does not reach any record already on disk or in the cloud.
         {
-            const slot = this.newSlot("maxRetries", 3);
+            const slot = this.newSlot("maxRetries", 0);
             slot.setLabel("Max Retries");
             slot.setInspectorPath("Settings");
             slot.setShouldStoreSlot(false);
             slot.setSyncsToView(true);
             slot.setDuplicateOp("duplicate");
             slot.setSlotType("Number");
+            slot.setIsSubnodeField(true);
+            slot.setCanEditInspection(false);
+            slot.setSummaryFormat("{key}:\n{value}");
+        }
+
+        // True only while the asyncSend() loop is waiting out the backoff delay
+        // between attempts. There is no live XHR to cancel in that window, so
+        // abort() consults this to stop the loop instead of doing nothing.
+        {
+            const slot = this.newSlot("isWaitingToRetry", false);
+            slot.setLabel("Is Waiting To Retry");
+            slot.setInspectorPath("State");
+            slot.setShouldStoreSlot(false);
+            slot.setSyncsToView(true);
+            slot.setDuplicateOp("duplicate");
+            slot.setSlotType("Boolean");
             slot.setIsSubnodeField(true);
             slot.setCanEditInspection(false);
             slot.setSummaryFormat("{key}:\n{value}");
@@ -590,8 +628,34 @@
 
 
     async asyncSend () { // does not throw errors - sets error if there is one. Caller must check hasError() and error()
-        this.setXhrPromise(Promise.clone());
         this.setCompletionPromise(Promise.clone());
+
+        while (true) {
+            await this.asyncSendOneAttempt();
+            if (!this.shouldRetryAfterAttempt()) {
+                break;
+            }
+            await this.asyncWaitForRetryDelay();
+            if (this.didAbort()) {
+                throw new Error("aborted"); // same rejection a mid-flight abort gives
+            }
+            this.prepareForRetryAttempt();
+        }
+
+        this.finishAfterFinalAttempt();
+    }
+
+    /**
+   * @category XHR
+   * @description Performs one attempt: builds the XHR, sends it, and waits for it
+   * to settle. The outcome is left on the request (error / status) for
+   * shouldRetryAfterAttempt() and finishAfterFinalAttempt() to classify.
+   * Rejects only when the request was aborted, which is how this class has always
+   * reported an abort to its caller.
+   * @returns {Promise}
+   */
+    async asyncSendOneAttempt () {
+        this.setXhrPromise(Promise.clone());
 
         this.setError(null); // clear error (in case we are retrying)
         assert(!this.xhr());
@@ -718,9 +782,82 @@
         }
 
         await this.xhrPromise(); // wait for the request to complete
+    }
 
+    /**
+   * @category XHR
+   * @description Whether the attempt that just finished ended in an error - a
+   * transport-level error, or an error status code.
+   * @returns {Boolean}
+   */
+    didAttemptFail () {
+        return Boolean(this.hasErrorStatusCode() || this.error());
+    }
+
+    /**
+   * @category XHR
+   * @description Whether the failed attempt that just finished should be sent
+   * again. Automatic retry is opt-in per request (see the maxRetries slot), so
+   * this is false by default no matter what the error was.
+   * @returns {Boolean}
+   */
+    shouldRetryAfterAttempt () {
+        if (!this.didAttemptFail()) {
+            return false;
+        }
+
+        if (this.maxRetries() < 1) {
+            return false; // automatic retry not enabled for this request
+        }
+
+        if (this.hasExceededMaxRetries()) {
+            return false;
+        }
+
+        return this.shouldAutoRetryForCurrentError();
+    }
+
+    /**
+   * @category XHR
+   * @description Waits out the backoff delay before the next attempt.
+   * @returns {Promise}
+   */
+    async asyncWaitForRetryDelay () {
+        const seconds = this.currentRetryDelaySeconds();
+        console.log(this.logPrefix(), "retrying in " + seconds + " seconds (retry "
+            + (this.retryCount() + 1) + " of " + this.maxRetries() + ")");
+        this.setIsWaitingToRetry(true);
+        await new Promise((resolve) => this.addTimeout(resolve, seconds * 1000));
+        this.setIsWaitingToRetry(false);
+    }
+
+    /**
+   * @category XHR
+   * @description Clears the per-attempt state so another attempt can be sent.
+   * Deliberately leaves completionPromise and didAbort alone: the completion
+   * promise spans all attempts, and an aborted request is never retried.
+   * @returns {SvXhrRequest}
+   */
+    prepareForRetryAttempt () {
+        this.setRetryCount(this.retryCount() + 1);
+        this.setError(null);
+        this.setDidTimeout(false);
+        this.setXhr(null);
+        this.setXhrPromise(null);
+        this.setStatus("retrying");
+        return this;
+    }
+
+    /**
+   * @category XHR
+   * @description Classifies the final outcome and tells the caller once. These
+   * delegate messages and the completionPromise resolution must happen exactly
+   * once per asyncSend(), after the LAST attempt - a caller that saw
+   * onRequestFailure for attempt 1 would give up while a retry was still in flight.
+   */
+    finishAfterFinalAttempt () {
         // only have a status error
-        if (this.hasErrorStatusCode() || this.error()) {
+        if (this.didAttemptFail()) {
             // If we don't already have an error set by onXhrError, create one
             if (!this.error()) {
                 const m = JSON.stringify(this.readableJsonState(), null, 2);
@@ -1035,12 +1172,8 @@
    * @description Retries the request
    */
     retryRequest () {
-        this.setRetryCount(this.retryCount() + 1);
-        this.setError(null);
-        this.setXhr(null);
-        this.setXhrPromise(null);
-        this.setCompletionPromise(null);
-        this.setStatus("retrying");
+        this.prepareForRetryAttempt();
+        this.setCompletionPromise(null); // asyncSend() makes a fresh one
         this.asyncSend();
     }
 
@@ -1075,31 +1208,7 @@
         }
     }
 
-    // --- retry helpers ---
-
-    // NOTE: not yet wired to any error path — kept correct for future use.
-    // (Was dead AND broken: referenced undefined vars and the max-retries
-    // predicate below was inverted, so if ever called it would only have
-    // retried AFTER retries were exhausted, then thrown a ReferenceError.)
-    retryIfApplicable () {
-        if (this.shouldAutoRetryForCurrentError() && !this.hasExceededMaxRetries()) {
-            const seconds = this.currentRetryDelaySeconds();
-            this.retryWithDelay(seconds);
-            return true;
-        }
-        return false;
-    }
-
-    /**
-   * @description Retries the request with a delay
-   * @param {number} seconds
-   */
-    retryWithDelay (seconds) {
-        console.log(this.logPrefix(), ".retryWithDelay(" + seconds + " seconds)");
-        this.addTimeout(() => {
-            this.retryRequest();
-        }, seconds * 1000);
-    }
+    // --- retry helpers (used by the asyncSend() attempt loop) ---
 
     hasExceededMaxRetries () {
         return this.retryCount() >= this.maxRetries();
@@ -1465,6 +1574,12 @@
     abort () {
         if (this.isActive()) {
             this.xhr().abort();
+        } else if (this.isWaitingToRetry()) {
+            // Between attempts there is no XHR to cancel, and without this an
+            // abort during the backoff window would be silently ignored and the
+            // next attempt sent anyway. The previous attempt's xhrPromise has
+            // already settled, so onXhrAbort()'s reject of it is a no-op.
+            this.onXhrAbort();
         }
         return this;
     }

--- a/source/library/services/Krea/Text to Image/SvKreaImageGeneration.js
+++ b/source/library/services/Krea/Text to Image/SvKreaImageGeneration.js
@@ -281,6 +281,9 @@
             const request = SvXhrRequest.clone();
             request.setUrl(proxyEndpoint);
             request.setMethod("GET");
+            // NOTE: deliberately NO setMaxRetries() here. A failed poll already
+            // retries at this level (schedulePoll, bounded by maxPollAttempts);
+            // a second retry underneath would multiply that attempt budget.
             // No Content-Type on a GET: Firebase returns 400 for a GET that
             // declares a body content type.
             request.setHeaders({
@@ -470,6 +473,11 @@
      * @category Results
      */
     async downloadImageUrls (imageUrls) {
+        // RETRIED, though nothing here says setMaxRetries: each image is an
+        // SvFileToDownload (images() is an SvFilesToDownload), and that class
+        // opts in to SvXhrRequest's automatic retry on its own behalf. A
+        // transient 502 on one image therefore no longer rejects this
+        // Promise.all and loses the whole generation.
         const authToken = await this.service().apiKeyOrUserAuthToken();
         const promises = imageUrls.map(async (imageUrl, index) => {
             const image = this.images().add();

--- a/source/library/services/Krea/Text to Image/SvKreaImagePrompt.js
+++ b/source/library/services/Krea/Text to Image/SvKreaImagePrompt.js
@@ -817,6 +817,11 @@
         request.setBody(JSON.stringify(bodyJson));
         this.setXhrRequest(request);
 
+        // NOTE: deliberately NO setMaxRetries() here. This POST creates a
+        // billable job, and the proxy raises its own 502 on a socket error that
+        // can fire after Krea has already accepted the request — so an automatic
+        // retry would charge the player for a job they will never see.
+
         await request.asyncSend();
 
         if (request.hasError()) {

--- a/tests/headless/TestXhrAutoRetry.js
+++ b/tests/headless/TestXhrAutoRetry.js
@@ -1,0 +1,410 @@
+#!/usr/bin/env node
+
+"use strict";
+
+/**
+ * Headless test: SvXhrRequest automatic-retry DECISION.
+ *
+ * A transient 502 — from an image host, or from our own /proxy when its upstream
+ * socket dies — used to kill a whole image generation: SvFileToDownload.fetch()
+ * throws on any non-2xx and the enclosing Promise.all over the download urls
+ * rejects. SvXhrRequest already knew which status codes are worth repeating
+ * (statusCodeMap) and already had the backoff math, but nothing called it.
+ *
+ * asyncSend() is now a send → await → classify loop. The behavior it must have:
+ *
+ *   - Automatic retry is OPT-IN. maxRetries defaults to 0, so an unmodified
+ *     request behaves exactly as it did before: one attempt, whatever the error.
+ *     This is what makes the change safe for the streaming path (SvAiRequest
+ *     consumes an SvXhrRequest incrementally) and for non-idempotent, billable
+ *     POSTs (an image job submit).
+ *   - With setMaxRetries(n), a retryable failure is repeated up to n times.
+ *   - Only retryable failures: a 404 / 400 is final, and an abort is never retried.
+ *   - onRequestFailure / onRequestSuccess / onRequestComplete and the
+ *     completionPromise resolution fire EXACTLY ONCE, after the final attempt.
+ *     A caller that saw onRequestFailure for attempt 1 would give up while a
+ *     retry was still in flight.
+ *
+ * The XHR itself is faked: a scripted global XMLHttpRequest is installed BEFORE
+ * boot, which also keeps XMLHttpRequestShim.js from requiring the xhr2 package.
+ *
+ * Usage (from the strvct root):
+ *   node source/boot/index-builder/ImportsIndexer.js   # if index is stale
+ *   node tests/headless/TestXhrAutoRetry.js
+ */
+
+const path = require("path");
+const { pathToFileURL } = require("url");
+
+// Boot expects cwd to be the site root (build/_index.json lives there).
+const strvctRoot = path.join(__dirname, "..", "..");
+process.chdir(strvctRoot);
+
+let passed = 0;
+let failed = 0;
+
+function check (condition, message) {
+    if (condition) {
+        passed++;
+        console.log("  \x1b[32m✓\x1b[0m " + message);
+    } else {
+        failed++;
+        console.log("  \x1b[31m✗\x1b[0m " + message);
+    }
+}
+
+// --- the scripted fake XHR -------------------------------------------------
+
+// Each entry is one attempt's outcome, consumed in order by send().
+let scriptedOutcomes = [];
+let attemptCount = 0;
+
+class FakeXMLHttpRequest {
+
+    constructor () {
+        this.readyState = 0;
+        this.status = 0;
+        this.statusText = "";
+        this.response = null;
+        this.responseText = "";
+        this.responseType = "";
+        this.timeout = 0;
+        this.listenersByName = new Map();
+    }
+
+    addEventListener (name, handler) {
+        if (!this.listenersByName.has(name)) {
+            this.listenersByName.set(name, []);
+        }
+        this.listenersByName.get(name).push(handler);
+    }
+
+    fire (name) {
+        const handlers = this.listenersByName.get(name) || [];
+        handlers.forEach((handler) => handler({ type: name, target: this }));
+    }
+
+    open (method, url) {
+        this.method = method;
+        this.url = url;
+        this.readyState = 1;
+    }
+
+    setRequestHeader () {
+    }
+
+    getResponseHeader (name) {
+        return name.toLowerCase() === "content-type" ? "text/plain" : null;
+    }
+
+    abort () {
+        this.deliver({ kind: "abort" });
+    }
+
+    send () {
+        attemptCount++;
+        const outcome = scriptedOutcomes.shift() || { kind: "status", status: 200 };
+        setTimeout(() => this.deliver(outcome), 0);
+    }
+
+    deliver (outcome) {
+        this.fire("loadstart");
+        this.readyState = 4;
+        if (outcome.kind === "status") {
+            this.status = outcome.status;
+            this.responseText = outcome.body || "";
+            if (this.status >= 200 && this.status < 300) {
+                this.fire("load");
+            }
+            this.fire("loadend");
+        } else if (outcome.kind === "networkError") {
+            this.fire("error");
+            this.fire("loadend");
+        } else if (outcome.kind === "timeout") {
+            this.fire("timeout");
+            this.fire("loadend");
+        } else if (outcome.kind === "abort") {
+            this.fire("abort");
+            this.fire("loadend");
+        }
+    }
+
+}
+
+global.XMLHttpRequest = FakeXMLHttpRequest;
+
+// --- boot ------------------------------------------------------------------
+
+async function boot () {
+    const bootFile = (p) => import(pathToFileURL(path.join(strvctRoot, p)).href);
+    await bootFile("source/boot/SvGlobals.js");
+    await bootFile("source/boot/SvPlatform.js");
+    await bootFile("source/boot/StrvctFile.js");
+    await bootFile("source/boot/SvBootLoader.js");
+
+    const SvBootLoader = SvGlobals.get("SvBootLoader");
+    SvBootLoader._bootPath = "source/boot";
+    await SvPlatform.promiseReady();
+    await StrvctFile.asyncLoadAndSequentiallyEvalPaths(SvBootLoader.fullPaths());
+
+    // Resources that need native modules unavailable in this environment (the
+    // canvas bindings) must not abort the boot — the model classes under test
+    // do not depend on them.
+    const originalSerialForEach = Array.prototype.promiseSerialForEach;
+    Array.prototype.promiseSerialForEach = async function (callback) {
+        for (let i = 0; i < this.length; i++) {
+            try {
+                await callback(this[i], i, this);
+            } catch {
+                // intentionally swallow
+            }
+        }
+    };
+    await SvResourceManager.shared().setupAndRun();
+    await SvResourceManager.shared().promiseCompleted();
+    Array.prototype.promiseSerialForEach = originalSerialForEach;
+}
+
+// --- helpers ---------------------------------------------------------------
+
+function newRecordingDelegate () {
+    const counts = {};
+    const record = (name) => { counts[name] = (counts[name] || 0) + 1; };
+    return {
+        counts: counts,
+        onRequestBegin: () => record("onRequestBegin"),
+        onRequestProgress: () => record("onRequestProgress"),
+        onRequestSuccess: () => record("onRequestSuccess"),
+        onRequestFailure: () => record("onRequestFailure"),
+        onRequestAbort: () => record("onRequestAbort"),
+        onRequestError: () => record("onRequestError"),
+        onRequestTimeout: () => record("onRequestTimeout"),
+        onRequestComplete: () => record("onRequestComplete")
+    };
+}
+
+function newRequest (maxRetries) {
+    const request = SvGlobals.get("SvXhrRequest").clone();
+    request.setUrl("https://example.com/image.png");
+    request.setMethod("GET");
+    request.setHeaders({});
+    request.setRetryDelaySeconds(0); // keep the test fast; backoff math is unchanged
+    if (maxRetries !== undefined) {
+        request.setMaxRetries(maxRetries);
+    }
+    return request;
+}
+
+// Counts every completionPromise the request creates and resolves. Call BEFORE
+// asyncSend(): the point is to catch a completion promise created (and settled)
+// per attempt rather than once per asyncSend().
+function watchCompletionPromises (request, counter) {
+    const originalSetter = request.setCompletionPromise.bind(request);
+    request.setCompletionPromise = function (aPromise) {
+        originalSetter(aPromise);
+        if (aPromise) {
+            counter.created++;
+            aPromise.then(() => { counter.resolutions++; });
+        }
+        return this;
+    };
+}
+
+async function runScript (request, outcomes) {
+    scriptedOutcomes = outcomes;
+    attemptCount = 0;
+    await request.asyncSend();
+    return attemptCount;
+}
+
+// --- tests -----------------------------------------------------------------
+
+function testRetriesAreOffByDefault () {
+    console.log("\nretries are opt-in");
+    const request = newRequest();
+    check(request.maxRetries() === 0, "maxRetries defaults to 0 (no automatic retries)");
+}
+
+async function testNoRetryWhenDisabled () {
+    console.log("\ndefault request: a 502 is NOT retried");
+    const request = newRequest();
+    const delegate = newRecordingDelegate();
+    request.setDelegate(delegate);
+
+    const attempts = await runScript(request, [{ kind: "status", status: 502 }]);
+
+    check(attempts === 1, "sent exactly one attempt");
+    check(request.hasError() === true, "request reports an error");
+    check(request.retryCount() === 0, "retryCount stayed 0");
+    check(delegate.counts.onRequestFailure === 1, "onRequestFailure sent once");
+    check(delegate.counts.onRequestComplete === 1, "onRequestComplete sent once");
+}
+
+async function testRetryThenSuccess () {
+    console.log("\nopted in: 502 then 200 succeeds");
+    const request = newRequest(3);
+    const delegate = newRecordingDelegate();
+    request.setDelegate(delegate);
+    const counter = { created: 0, resolutions: 0 };
+    watchCompletionPromises(request, counter);
+
+    const attempts = await runScript(request, [
+        { kind: "status", status: 502 },
+        { kind: "status", status: 200, body: "ok" }
+    ]);
+    await request.completionPromise();
+
+    check(attempts === 2, "sent two attempts");
+    check(request.hasError() === false, "final state is success");
+    check(request.retryCount() === 1, "retryCount is 1");
+    check(delegate.counts.onRequestSuccess === 1, "onRequestSuccess sent once");
+    check(delegate.counts.onRequestFailure === undefined, "onRequestFailure never sent");
+    check(delegate.counts.onRequestComplete === 1, "onRequestComplete sent once, after the last attempt");
+    check(counter.created === 1, "one completionPromise for the whole asyncSend, not one per attempt");
+    check(counter.resolutions === 1, "completionPromise resolved exactly once");
+}
+
+async function testGivesUpAfterMaxRetries () {
+    console.log("\nopted in: gives up after maxRetries");
+    const request = newRequest(2);
+    const delegate = newRecordingDelegate();
+    request.setDelegate(delegate);
+
+    const attempts = await runScript(request, [
+        { kind: "status", status: 502 },
+        { kind: "status", status: 503 },
+        { kind: "status", status: 502 },
+        { kind: "status", status: 200 } // must never be reached
+    ]);
+
+    check(attempts === 3, "sent the initial attempt plus 2 retries");
+    check(request.hasError() === true, "still an error");
+    check(request.retryCount() === 2, "retryCount is 2");
+    check(delegate.counts.onRequestFailure === 1, "onRequestFailure sent once, not once per attempt");
+    check(delegate.counts.onRequestComplete === 1, "onRequestComplete sent once");
+}
+
+async function testNoRetryForFinalStatusCodes () {
+    console.log("\nopted in: 404 and 400 are final");
+    for (const status of [404, 400]) {
+        const request = newRequest(3);
+        const attempts = await runScript(request, [
+            { kind: "status", status: status },
+            { kind: "status", status: 200 } // must never be reached
+        ]);
+        check(attempts === 1, status + " is not retried");
+        check(request.hasError() === true, status + " leaves the request in error");
+    }
+}
+
+async function testRetriesTimeout () {
+    console.log("\nopted in: a timeout is retried");
+    const request = newRequest(3);
+    const attempts = await runScript(request, [
+        { kind: "timeout" },
+        { kind: "status", status: 200 }
+    ]);
+    check(attempts === 2, "timed-out attempt was repeated");
+    check(request.hasError() === false, "the retry succeeded");
+    check(request.didTimeout() === false, "didTimeout was cleared for the new attempt");
+}
+
+async function testRetriesNetworkError () {
+    console.log("\nopted in: a transport error is retried");
+    const request = newRequest(3);
+    const attempts = await runScript(request, [
+        { kind: "networkError" },
+        { kind: "status", status: 200 }
+    ]);
+    check(attempts === 2, "failed attempt was repeated");
+    check(request.hasError() === false, "the retry succeeded");
+}
+
+async function testAbortIsNeverRetried () {
+    console.log("\nopted in: an abort is never retried");
+    const request = newRequest(3);
+    const delegate = newRecordingDelegate();
+    request.setDelegate(delegate);
+
+    let threw = false;
+    try {
+        await runScript(request, [
+            { kind: "abort" },
+            { kind: "status", status: 200 } // must never be reached
+        ]);
+    } catch {
+        threw = true;
+    }
+
+    check(attemptCount === 1, "only one attempt was sent");
+    check(threw === true, "asyncSend still rejects on abort, as before");
+    check(request.didAbort() === true, "the request is marked aborted");
+    check(delegate.counts.onRequestAbort === 1, "onRequestAbort sent once");
+    check(delegate.counts.onRequestFailure === undefined, "no onRequestFailure for an abort");
+}
+
+async function testAbortDuringBackoffStopsTheLoop () {
+    console.log("\nopted in: aborting during the backoff window stops the retry");
+    const request = newRequest(3);
+    const delegate = newRecordingDelegate();
+    request.setDelegate(delegate);
+    request.setRetryDelaySeconds(1); // wide enough to abort inside it
+
+    scriptedOutcomes = [
+        { kind: "status", status: 502 },
+        { kind: "status", status: 200 } // must never be reached
+    ];
+    attemptCount = 0;
+
+    const sendPromise = request.asyncSend();
+    // Wait for the first attempt to fail and the loop to enter its backoff.
+    while (!request.isWaitingToRetry()) {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    request.abort();
+
+    let threw = false;
+    try {
+        await sendPromise;
+    } catch {
+        threw = true;
+    }
+
+    check(attemptCount === 1, "the queued retry was never sent");
+    check(threw === true, "asyncSend rejects, as it does for a mid-flight abort");
+    check(request.didAbort() === true, "the request is marked aborted");
+    check(delegate.counts.onRequestAbort === 1, "onRequestAbort sent once");
+    check(delegate.counts.onRequestComplete === undefined, "no onRequestComplete for an abort");
+}
+
+async function testShouldRetryPredicate () {
+    console.log("\nshouldRetryAfterAttempt() consults the status map");
+    const request = newRequest(3);
+    await runScript(request, [{ kind: "status", status: 200 }]);
+    check(request.shouldRetryAfterAttempt() === false, "a success is never retried");
+    check(request.didAttemptFail() === false, "a success did not fail");
+}
+
+async function main () {
+    console.log("TestXhrAutoRetry: booting strvct…");
+    await boot();
+
+    testRetriesAreOffByDefault();
+    await testNoRetryWhenDisabled();
+    await testRetryThenSuccess();
+    await testGivesUpAfterMaxRetries();
+    await testNoRetryForFinalStatusCodes();
+    await testRetriesTimeout();
+    await testRetriesNetworkError();
+    await testAbortIsNeverRetried();
+    await testAbortDuringBackoffStopsTheLoop();
+    await testShouldRetryPredicate();
+
+    console.log("\n" + passed + " passed, " + failed + " failed");
+    process.exit(failed === 0 ? 0 : 1);
+}
+
+main().catch((e) => {
+    console.error("BOOT FAILURE:", e);
+    process.exit(1);
+});


### PR DESCRIPTION
**Stack: this is PR 2 of 2.** It sits on top of #47, which moves `SvFileToDownload` out of the ImaginePro directory. Review #47 first; this PR's diff assumes it.

## Which Krea calls retry, since the diff makes this easy to misread

Neither Krea file gains a `setMaxRetries()` here, and both gain a comment saying so. That reads as "Krea gets no retries." It is not what happens:

| Krea call | Retried? | Why |
|---|---|---|
| Submit `POST` (`SvKreaImagePrompt.asyncSubmitJob`) | No | Creates a billable job; see below |
| Poll `GET` (`SvKreaImageGeneration.pollJobStatus`) | **Yes, already** | Its own loop, bounded by `maxPollAttempts` |
| **Image download `GET`** (`downloadImageUrls`) | **Yes — new here** | This is the call that was failing |

`downloadImageUrls()` calls `this.images().add()`; `images` is an `SvFilesToDownload`, whose `setSubnodeClasses([SvFileToDownload])` makes every Krea image download an `SvFileToDownload` — precisely the class that opts in. So the 502 that motivated this PR is retried; it just opts in one layer down. #47 exists so that layer is no longer filed under a competitor's name, and `downloadImageUrls` now carries a comment pointing at it.

---

## The bug

A transient 502 kills an entire image generation. `SvFileToDownload.fetch()` throws on any non-2xx, and `SvKreaImageGeneration.downloadImageUrls()` wraps the downloads in a `Promise.all`, so one bad gateway on one of four images loses all four — after the job was generated and billed. The 502 comes either from the image host or from our own `/proxy`, which raises one when its upstream socket dies.

## The mechanism already existed, unwired

`SvXhrRequest` already had all of it and never called it:

- slots `maxRetries`, `retryDelaySeconds`, `retryCount`
- `currentRetryDelaySeconds()` — exponential backoff with jitter
- `shouldAutoRetryForCurrentError()` — timeout → retry, abort → no, else consult the status map
- `statusCodeMap()` — already marks `0, 408, 429, 500, 502, 503, 504` as `shouldAutoRetry: true`

The only thing joining them to an error path was `retryIfApplicable()`, and nothing called `retryIfApplicable()`. This PR wires up what was there rather than adding a second mechanism.

## What changed

**`asyncSend()` is now a send → await → classify loop.** The per-attempt work moved to `asyncSendOneAttempt()`; classification happens once in `finishAfterFinalAttempt()`. `onRequestFailure` / `onRequestSuccess` / `onRequestComplete` and the `completionPromise` resolution still fire **exactly once per `asyncSend()`, after the final attempt** — a caller that saw `onRequestFailure` for attempt 1 would give up while a retry was still in flight.

**Retry is opt-in and off by default.** `maxRetries` now defaults to **0** instead of 3, so an unmodified request behaves exactly as it did before. That is the property that makes this landable: with retries disabled, the code path is the same one as today, just split across named methods.

Off-by-default is deliberate, not caution — blanket retry is wrong for two of the three callers:

- **Streaming duplication.** `SvAiRequest` does not extend `SvXhrRequest`; it *composes* one and consumes it incrementally (`readIndex`, `fullContent`, `onStreamData`) with its own continuation logic. A silent restart would re-deliver the prefix it has already read.
- **Non-idempotent POSTs / double billing.** A submit POST creates a billable job, and the proxy's 502 can fire *after* the upstream accepted the request. Retrying charges the player for a job they will never see.

**Slot-flag decision:** repurposed the existing `maxRetries` slot rather than adding a new `autoRetries` concept. It carries `setShouldStoreSlot(false)`, so changing its default reaches no record already on disk or in the cloud, and `hasExceededMaxRetries()` works unchanged. Nothing in the framework or the app reads `maxRetries` today except that predicate, and the manual "Retry Request" inspector action never consulted it, so the default change has no other effect.

**Exactly one caller opts in:** `SvFileToDownload`, with `setMaxRetries(3)`. That one file covers **both** the Krea and the ImaginePro image downloads. The request is a GET of finished, immutable bytes for a job that has already been billed — repeating it cannot duplicate work or double-charge.

**Deliberately left alone**, with a `NOTE` at each site so the omission does not read as an oversight:

- the Krea submit POST — billing, above;
- the Krea poll loop — it already retries at its own level bounded by `maxPollAttempts`; a second retry underneath would multiply that budget.

**One gap the loop introduced, closed here.** Between attempts there is no live XHR, so `abort()` had nothing to cancel and the queued retry would have been sent anyway — a `shutdown()` during the backoff window would still have completed the download. `isWaitingToRetry` marks that window; `abort()` stops the loop and rejects with the same `"aborted"` error a mid-flight abort gives. This is the one piece beyond the minimal wiring; it is easy to drop if you would rather it were separate.

**Removed** `retryIfApplicable()` and `retryWithDelay()`. Both were dead, and both are now the loop — leaving near-duplicates of it in the file invites exactly the confusion the old `// NOTE: not yet wired` comment was warning about.

## Verification

`tests/headless/TestXhrAutoRetry.js` drives the retry *decision* against a scripted fake XHR installed as the global before boot (which also keeps `XMLHttpRequestShim.js` from requiring `xhr2`). **Actually run: 40 passed, 0 failed.**

Covered: off by default (a 502 is not retried, one attempt, `onRequestFailure` once); 502-then-200 succeeds on attempt 2; gives up after exactly `maxRetries` retries with `onRequestFailure` sent once rather than once per attempt; 404 and 400 are final; a timeout is retried and `didTimeout` is cleared for the new attempt; a transport error is retried; an abort is never retried, in flight or during backoff; one `completionPromise` per `asyncSend`, resolved once.

`npx eslint` over the five touched files reports only the two pre-existing `no-unused-vars` in `SvXhrRequest.js` (`displayUrl` / `urlWithoutQuery`), the same two it reports on `master`.

Not verified against a live 502 — the fake XHR exercises the decision, not the network.

## Notes

- The other headless tests in this tree cannot run in my environment: the boot requires `xhr2` from `node_modules`, which is absent here, and installing it was not an option. That failure predates this branch. `TestXhrAutoRetry` sidesteps it by installing its fake `XMLHttpRequest` global before boot.
- `onRequestBegin` / `onRequestProgress` / `onRequestError` still fire **per attempt** — they describe one attempt, and no delegate in the tree is confused by that (`SvFileToDownload.onLoaded()` clears the error a retried attempt's `onRequestError` set). Only the three terminal messages are collapsed to once.
- Leonardo's image download does **not** go through `SvXhrRequest` at all — it uses raw `fetch()` — so it is not covered by this and would need a separate change.
- `retryRequest()` (the manual inspector action) now also clears `didTimeout`, via the shared `prepareForRetryAttempt()`. Previously a manually retried timeout kept `didTimeout` true. It still does not clear `didAbort`, which remains a latent hazard for manually retrying an aborted request — pre-existing, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

