### PR TITLE
Land the two commits UO already pins but master never received

### DIFF
--- a/source/library/node/blobs/SvCloudBlobNode.js
+++ b/source/library/node/blobs/SvCloudBlobNode.js
@@ -407,12 +407,17 @@
      */
     didUpdateSlotValueHash (oldValue, newValue) {
         super.didUpdateSlotValueHash(oldValue, newValue);
-        if (oldValue !== null && newValue !== null && oldValue !== newValue) {
-            this.setHasInCloud(false); // old content's cloud state does not describe the new hash
-            this.setDownloadUrl(null); // old content's URL
-            this.clearPushToCloudPromise(); // abandon any in-flight push of the old bytes
-            this.scheduleFetchForNewContent();
+        if (newValue === null || newValue === oldValue) {
+            return;
         }
+        if (oldValue !== null) {
+            // REPLACING content: the previous hash's cloud state and URL
+            // describe bytes this node no longer claims.
+            this.setHasInCloud(false);
+            this.setDownloadUrl(null);
+            this.clearPushToCloudPromise(); // abandon any in-flight push of the old bytes
+        }
+        this.scheduleFetchForNewContent();
     }
 
     /**
@@ -434,20 +439,33 @@
      * Found" on the receiving side. The blob path pulls from the cloud BY HASH,
      * which is exactly what a receiver needs. blobValue syncsToView, so the view
      * repaints when the bytes land.
+     *
+     * FIRST content counts too (2026-09-10). This used to be reached only when
+     * one hash REPLACED another, on the theory that the authoring side is the
+     * one whose hash moves old -> null -> new. But so does a receiver seeing
+     * content for the first time: a newly generated portrait arrives as a whole
+     * new artwork item whose imageNode goes null -> hash, and that was silently
+     * excluded — the client held a hash and no bytes, and nothing fetched them.
+     * Every hash change to a non-null value now schedules; the authoring side is
+     * excluded by onScheduledFetchForNewContent's blobValue check instead, which
+     * is the accurate test (it asks "do I have the bytes?" rather than inferring
+     * it from the shape of the transition).
      * @category Cloud Storage
      */
     scheduleFetchForNewContent () {
-        // No blobValue check here: super's hook has ALREADY dropped the cached
-        // bytes by this point, precisely because they belonged to the old hash.
-        // The authoring side is excluded by the both-non-null guard instead — its
-        // hash moves old -> null -> new — so anything reaching here needs bytes it
-        // does not have.
+        // No blobValue check HERE: when one hash replaces another, super's hook
+        // has already dropped the cached bytes, but on a first-content set the
+        // author still holds them. Deciding at run time covers both — see
+        // onScheduledFetchForNewContent.
         SvSyncScheduler.shared().scheduleTargetAndMethod(this, "onScheduledFetchForNewContent");
     }
 
     onScheduledFetchForNewContent () {
         if (this.blobValue()) {
-            return; // something supplied them between the schedule and now
+            // Either something supplied the bytes between the schedule and now,
+            // or this IS the authoring side (asyncJustSetBlobValue sets the blob
+            // before it computes the hash, so the bytes are already in hand).
+            return;
         }
         // fire and forget: a miss is already logged by the pull path, and a
         // failure here must not break whatever applied the update

--- a/source/library/notification/SvSyncScheduler.js
+++ b/source/library/notification/SvSyncScheduler.js
@@ -491,7 +491,23 @@
                     console.log("\n" + SvNotificationCenter.shared().shortDescription() + ":\n" + SvNotificationCenter.shared().notesDescription());
                     console.log(" --- ");
                 }
-                assert (count < maxCount);
+                if (count >= maxCount) {
+                    // A DEEP CASCADE, not a loop: a genuine loop is caught
+                    // earlier, per action, by scheduleTargetAndMethod's
+                    // LOOP DETECTED throw (same target+method re-scheduled
+                    // from inside its own processing). Ten passes can be
+                    // legitimate — opening a session materializes lazy
+                    // character sections, each bubbles an update, observers
+                    // re-sync, views re-style (2026-09-10, a client hit 10).
+                    // Asserting here threw out of the event handler and
+                    // dropped the rest of the pass. Yield instead: leave the
+                    // remaining actions queued for the next tick so the UI
+                    // stays live and the cascade finishes on its own.
+                    console.warn("SvSyncScheduler: " + count + " passes in one fullSyncNow; deferring "
+                        + this.actionCount() + " remaining action(s) to the next tick");
+                    this.setTimeoutIfNeeded();
+                    break;
+                }
             }
 
             this.logDebug(" --- fullSyncNow end --- ");

--- a/tests/headless/TestBlobHashChange.js
+++ b/tests/headless/TestBlobHashChange.js
@@ -29,6 +29,15 @@
  * deserialize path via Slot.onInstanceSetValue(), which is what
  * SvJsonGroup.setSlotsJson() uses during envelope deserialization.
  *
+ * The same hook has a SECOND job (SvCloudBlobNode): after the content identity
+ * changes, go and fetch the new bytes rather than waiting for a view to ask.
+ * That half was governed by the same both-non-null guard and so covered only
+ * REPLACEMENT — a receiver seeing content for the FIRST time (null → hash, how
+ * a newly generated portrait arrives at a client) was silently skipped, leaving
+ * it holding a hash and no bytes. The fetch now fires for every change to a
+ * non-null hash, with the authoring side excluded by the run-time blobValue
+ * check instead of by the shape of the transition.
+ *
  * Usage (from the strvct root):
  *   node source/boot/index-builder/ImportsIndexer.js   # if index is stale
  *   node tests/headless/TestBlobHashChange.js
@@ -176,6 +185,94 @@ function testDeserializePathClears () {
     check(node.publicUrl() === null, "stale publicUrl cleared through the deserialize path");
 }
 
+// --- fetch-for-new-content scheduling (SvCloudBlobNode) ---
+
+/**
+ * Runs fn with scheduleFetchForNewContent counted rather than scheduled, and
+ * returns how many times it was reached. Counting the SCHEDULE (not the async
+ * fetch) keeps the test off the network while still asserting the decision.
+ */
+function countingFetchSchedules (fn) {
+    const proto = SvGlobals.get("SvCloudBlobNode").prototype;
+    const original = proto.scheduleFetchForNewContent;
+    let count = 0;
+    proto.scheduleFetchForNewContent = function () { count += 1; return this; };
+    try { fn(); } finally { proto.scheduleFetchForNewContent = original; }
+    return count;
+}
+
+function testFetchScheduledOnReplacement () {
+    console.log("\nFetch: replacing one hash with another schedules a fetch");
+
+    const node = SvGlobals.get("SvImageNode").clone();
+    node.setValueHash(HASH_A);
+    const count = countingFetchSchedules(() => node.setValueHash(HASH_B));
+    check(count === 1, "hash A → B schedules a fetch");
+}
+
+function testFetchScheduledOnFirstContent () {
+    console.log("\nFetch: FIRST content (null → hash) schedules a fetch");
+
+    // A client receiving newly generated artwork: the imageNode arrives with a
+    // hash it has never held bytes for. This was the gap — the old guard read
+    // null → hash as "the author computing its own hash" and skipped it.
+    const node = SvGlobals.get("SvImageNode").clone();
+    check(node.valueHash() === null, "precondition: valueHash is null");
+    check(node.blobValue() === null, "precondition: no bytes in hand");
+    const count = countingFetchSchedules(() => node.setValueHash(HASH_A));
+    check(count === 1, "null → hash schedules a fetch for a receiver");
+}
+
+function testNoFetchOnClearOrNoOp () {
+    console.log("\nFetch: clearing the hash, or re-setting it, schedules nothing");
+
+    const node = SvGlobals.get("SvImageNode").clone();
+    node.setValueHash(HASH_A);
+    check(countingFetchSchedules(() => node.setValueHash(null)) === 0,
+        "hash → null schedules nothing (there is no content to fetch)");
+    node.setValueHash(HASH_A);
+    check(countingFetchSchedules(() => node.setValueHash(HASH_A)) === 0,
+        "re-setting the same hash schedules nothing");
+}
+
+function testAuthorWithBytesDoesNotFetch () {
+    console.log("\nFetch: the authoring side no-ops at run time (it has the bytes)");
+
+    // asyncJustSetBlobValue sets the blob BEFORE computing the hash, so on the
+    // machine that made the content the bytes are already in hand when the
+    // hash lands. The schedule still happens; the scheduled method is what
+    // declines — an accurate "do I have the bytes?" test rather than one
+    // inferred from the shape of the hash transition.
+    const node = SvGlobals.get("SvImageNode").clone();
+    const fakeBlob = { marker: "authored-bytes" };
+    node._blobValue = fakeBlob;
+    node.setValueHash(HASH_A);
+
+    let fetched = false;
+    const originalAsync = node.asyncBlobValue;
+    node.asyncBlobValue = function () { fetched = true; return Promise.resolve(fakeBlob); };
+    node.onScheduledFetchForNewContent();
+    node.asyncBlobValue = originalAsync;
+
+    check(fetched === false, "author holding the bytes does not fetch them again");
+}
+
+function testReceiverWithoutBytesFetches () {
+    console.log("\nFetch: a receiver holding only a hash does fetch");
+
+    const node = SvGlobals.get("SvImageNode").clone();
+    node.setValueHash(HASH_A);
+    check(node.blobValue() === null, "precondition: hash but no bytes");
+
+    let fetched = false;
+    const originalAsync = node.asyncBlobValue;
+    node.asyncBlobValue = function () { fetched = true; return Promise.resolve(null); };
+    node.onScheduledFetchForNewContent();
+    node.asyncBlobValue = originalAsync;
+
+    check(fetched === true, "receiver with no bytes pulls them by hash");
+}
+
 async function main () {
     console.log("TestBlobHashChange: booting strvct…");
     await boot();
@@ -187,6 +284,12 @@ async function main () {
     testNullToHashKeepsBlob();
     testSameHashIsNoOp();
     testDeserializePathClears();
+
+    testFetchScheduledOnReplacement();
+    testFetchScheduledOnFirstContent();
+    testNoFetchOnClearOrNoOp();
+    testAuthorWithBytesDoesNotFetch();
+    testReceiverWithoutBytesFetches();
 
     console.log("\n" + passed + " passed, " + failed + " failed");
     process.exit(failed === 0 ? 0 : 1);


### PR DESCRIPTION
## What this is

`undreamedof.ai`'s `main` pins strvct `263d52f3`, and that commit is **not reachable from `master`**. This merges it in, so master finally contains what the app is built against.

Exactly two commits arrive — `c1b93c62` is already on master via #45, so nothing else rides along:

| Commit | |
|---|---|
| `24149314` | Fetch blob bytes for FIRST content, not only for replaced content |
| `263d52f3` | Scheduler yields after ten passes instead of asserting |

3 files, +148/−11. No conflicts.

## How they got stranded

```
2026-09-10 14:35   #45 merges release/document-metadata-20260910 → master, at c1b93c62
2026-09-10 15:02   24149314 pushed onto that same branch — after its PR had merged
2026-09-10 15:20   263d52f3 pushed onto it
                   the app pins the new tip directly (app commits d6e3f51a3, 61bcbd6bb)
                   no further PR ever carries them to master
```

The release branch kept being used after its PR landed, so the app has been pinned two commits ahead of `master` ever since. Nothing was done wrong in any individual step — it's just that the second push had no PR behind it.

## Why it matters beyond tidiness

Master's `SvCloudBlobNode.didUpdateSlotValueHash` still carries the original guard:

```js
if (oldValue !== null && newValue !== null && oldValue !== newValue) {
```

so a client seeing content for the **first** time (`null → hash`) never schedules the byte fetch — newly generated artwork arrives as a hash with nothing behind it. That's precisely the bug `24149314` fixes, and `master` has been without it this whole time. Anyone branching from master inherits that.

## Deliberately left behind

`6180b06c` (*SvRenderedText: capture what the reader sees*) was pushed to the same release branch on 2026-09-11. It is newer than anything UO pins and hasn't been reviewed, so this merges the **commit** `263d52f3` rather than the branch tip. It stays on the release branch for its own PR.

## Verification

- `6180b06c` confirmed excluded (`git merge-base --is-ancestor` → false).
- Content confirmed present after merge: the first-content fetch in `SvCloudBlobNode.js` and the yield branch in `SvSyncScheduler.js`.
- `TestXhrAutoRetry` — **40 passed, 0 failed** on the merge result, so the retry work from #46 is unaffected.
- `TestBlobHashChange` (the test `24149314` shipped with) **could not be run here**: the headless boot needs `xhr2` from `node_modules`, which is absent in this environment, and installing it wasn't an option. It fails identically on pre-merge `master`, so this is a pre-existing environment limitation, not a regression — but it does mean that suite is unverified by me on this branch.

## Note for the app side

These two commits are pinned on the app's `main` but are **not** in production, which still runs `c1b93c62`. A UO pin bump to the resulting master follows this PR. Because #47 moved files between directories, the app's import index is stale across that bump and needs a rebuild — `site/build/` is gitignored, so nothing is committed for it, and `firebase.json`'s `predeploy: just build-firebase` covers the deploy path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
